### PR TITLE
Bug fixes and improvements

### DIFF
--- a/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
@@ -428,6 +428,7 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
           </IconButton>
         )}
       </Box>
+      <Divider />
       <Typography variant="h6" component="h2">
         Destination
       </Typography>
@@ -494,6 +495,8 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
           </IconButton>
         )}
       </Box>
+
+      <Divider />
 
       <Controller
         name="driverDeviationBudget"

--- a/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
@@ -22,12 +22,14 @@ import { useEffect, useState } from 'react';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { useAuthorities } from '../../../shared/hooks/useAuthorities.tsx';
 import { useOperators } from '../hooks/useOperators.tsx';
+import { useStreetRoute } from '../hooks/useStreetRoute.tsx';
 import type { Feature, Point, Position } from 'geojson';
 import type { CarPoolingTripDataFormData } from '../model/CarPoolingTripDataFormData.tsx';
 import { carPoolingTripDataSchema } from '../model/carPoolingTripDataSchema.tsx';
 import { humanizeCode } from '../../../shared/error-message/humanizeCode.tsx';
 import type { AppError } from '../../../shared/error-message/AppError.tsx';
 import type { Extrajourney } from '../../../shared/model/Extrajourney.tsx';
+import dayjs from 'dayjs';
 
 export interface CarPoolingTripDataFormProps {
   initialState?: CarPoolingTripDataFormData;
@@ -84,10 +86,11 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
       departureDestinationDisplay: 'Departure Display',
       destinationDestinationDisplay: 'Destination Display',
       departureStopName: '',
+      departureDatetime: dayjs(),
       departureFlexibleStop: null,
       destinationStopName: '',
       destinationFlexibleStop: null,
-      driverDeviationBudget: null,
+      driverDeviationBudget: 5,
       contactUrl: null,
       totalCapacity: null,
       onboardCount: null,
@@ -97,6 +100,8 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
   const authority = watch('authority');
   const departureFlexibleStop: Position | null = watch('departureFlexibleStop');
   const destinationFlexibleStop: Position | null = watch('destinationFlexibleStop');
+  const departureDatetime = watch('departureDatetime');
+  const streetRoute = useStreetRoute();
   const [error, setError] = useState<AppError | undefined>(undefined);
   const [errorDismissed, setErrorDismissed] = useState<boolean>(false);
   const [initialStateSet, setInitialStateSet] = useState<boolean>(false);
@@ -155,6 +160,48 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     error,
     errors?.departureFlexibleStop?.message,
     errors?.destinationFlexibleStop?.message,
+  ]);
+
+  const departureLng = departureFlexibleStop?.[0];
+  const departureLat = departureFlexibleStop?.[1];
+  const destinationLng = destinationFlexibleStop?.[0];
+  const destinationLat = destinationFlexibleStop?.[1];
+  const departureMs = departureDatetime?.isValid() ? departureDatetime.valueOf() : undefined;
+
+  useEffect(() => {
+    if (
+      departureLng == null ||
+      departureLat == null ||
+      destinationLng == null ||
+      destinationLat == null ||
+      departureMs == null
+    ) {
+      return;
+    }
+    let cancelled = false;
+    streetRoute(
+      [departureLng, departureLat],
+      [destinationLng, destinationLat],
+      dayjs(departureMs).toISOString()
+    )
+      .then(result => {
+        if (cancelled || !result?.expectedEndTime) return;
+        setValue('destinationDatetime', dayjs(result.expectedEndTime));
+      })
+      .catch(() => {
+        // Ignore street-routing failures; user can still set arrival manually.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    departureLng,
+    departureLat,
+    destinationLng,
+    destinationLat,
+    departureMs,
+    streetRoute,
+    setValue,
   ]);
 
   // Helper function to determine stop type and get appropriate icon/color

--- a/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
@@ -81,7 +81,6 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
       authority: '',
       operator: '',
       id: undefined,
-      lineName: '',
       destinationDisplay: '',
       departureStopName: '',
       departureFlexibleStop: null,
@@ -347,22 +346,6 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
         />
         <FormHelperText>{errors.operator?.message}</FormHelperText>
       </FormControl>
-      <Controller
-        name="lineName"
-        control={control}
-        render={({ field }) => {
-          return (
-            <TextField
-              {...field}
-              label="Line name"
-              error={!!errors.lineName}
-              helperText={errors.lineName?.message}
-              required
-              fullWidth
-            />
-          );
-        }}
-      />
       <Controller
         name="destinationDisplay"
         control={control}

--- a/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
@@ -81,7 +81,8 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
       authority: '',
       operator: '',
       id: undefined,
-      destinationDisplay: '',
+      departureDestinationDisplay: 'Departure Display',
+      destinationDestinationDisplay: 'Destination Display',
       departureStopName: '',
       departureFlexibleStop: null,
       destinationStopName: '',
@@ -346,25 +347,25 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
         />
         <FormHelperText>{errors.operator?.message}</FormHelperText>
       </FormControl>
+      <Typography variant="h6" component="h2">
+        Departure
+      </Typography>
       <Controller
-        name="destinationDisplay"
+        name="departureDestinationDisplay"
         control={control}
         render={({ field }) => {
           return (
             <TextField
               {...field}
               label="Destination display"
-              error={!!errors.destinationDisplay}
-              helperText={errors.destinationDisplay?.message}
+              error={!!errors.departureDestinationDisplay}
+              helperText={errors.departureDestinationDisplay?.message}
               required
               fullWidth
             />
           );
         }}
       />
-      <Typography variant="h6" component="h2">
-        Departure
-      </Typography>
       <Controller
         name="departureStopName"
         control={control}
@@ -432,6 +433,22 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
       <Typography variant="h6" component="h2">
         Destination
       </Typography>
+      <Controller
+        name="destinationDestinationDisplay"
+        control={control}
+        render={({ field }) => {
+          return (
+            <TextField
+              {...field}
+              label="Destination display"
+              error={!!errors.destinationDestinationDisplay}
+              helperText={errors.destinationDestinationDisplay?.message}
+              required
+              fullWidth
+            />
+          );
+        }}
+      />
       <Controller
         name="destinationStopName"
         control={control}

--- a/src/features/plan-trip/hooks/useStreetRoute.tsx
+++ b/src/features/plan-trip/hooks/useStreetRoute.tsx
@@ -1,0 +1,13 @@
+import { useCallback } from 'react';
+import { useConfig } from '../../../contexts/ConfigContext.tsx';
+import api from '../../../shared/api/api.tsx';
+import type { Position } from 'geojson';
+
+export const useStreetRoute = () => {
+  const config = useConfig();
+  return useCallback(
+    (from: Position, to: Position, dateTime: string) =>
+      api(config).getStreetRoute(from, to, dateTime),
+    [config]
+  );
+};

--- a/src/features/plan-trip/model/CarPoolingTripDataFormData.tsx
+++ b/src/features/plan-trip/model/CarPoolingTripDataFormData.tsx
@@ -8,7 +8,8 @@ export type CarPoolingTripDataFormData = {
   id?: string;
   lineRef?: string;
   estimatedVehicleJourneyCode?: string;
-  destinationDisplay: string;
+  departureDestinationDisplay: string;
+  destinationDestinationDisplay: string;
   departureStopName: string;
   departureDatetime: Dayjs;
   departureFlexibleStop: Position | null;

--- a/src/features/plan-trip/model/CarPoolingTripDataFormData.tsx
+++ b/src/features/plan-trip/model/CarPoolingTripDataFormData.tsx
@@ -8,7 +8,6 @@ export type CarPoolingTripDataFormData = {
   id?: string;
   lineRef?: string;
   estimatedVehicleJourneyCode?: string;
-  lineName: string;
   destinationDisplay: string;
   departureStopName: string;
   departureDatetime: Dayjs;

--- a/src/features/plan-trip/model/CarPoolingTripDataFormData.tsx
+++ b/src/features/plan-trip/model/CarPoolingTripDataFormData.tsx
@@ -16,7 +16,7 @@ export type CarPoolingTripDataFormData = {
   destinationStopName: string;
   destinationDatetime: Dayjs;
   destinationFlexibleStop: Position | null;
-  driverDeviationBudget: number | null;
+  driverDeviationBudget: number;
   contactUrl: string | null;
   totalCapacity: number | null;
   onboardCount: number | null;

--- a/src/features/plan-trip/model/carPoolingTripDataSchema.tsx
+++ b/src/features/plan-trip/model/carPoolingTripDataSchema.tsx
@@ -34,8 +34,11 @@ export const carPoolingTripDataSchema = Yup.object({
   codespace: Yup.string().required().length(3),
   authority: Yup.string().required(),
   operator: Yup.string().required(),
-  destinationDisplay: Yup.string()
-    .min(3, 'Destination display must be at least 3 characters')
+  departureDestinationDisplay: Yup.string()
+    .min(3, 'Departure destination display must be at least 3 characters')
+    .required(),
+  destinationDestinationDisplay: Yup.string()
+    .min(3, 'Destination destination display must be at least 3 characters')
     .required(),
   departureStopName: Yup.string()
     .min(3, 'Departure stop name must be at least 3 characters')

--- a/src/features/plan-trip/model/carPoolingTripDataSchema.tsx
+++ b/src/features/plan-trip/model/carPoolingTripDataSchema.tsx
@@ -34,7 +34,6 @@ export const carPoolingTripDataSchema = Yup.object({
   codespace: Yup.string().required().length(3),
   authority: Yup.string().required(),
   operator: Yup.string().required(),
-  lineName: Yup.string().min(3, 'Line name must be at least 3 characters').required(),
   destinationDisplay: Yup.string()
     .min(3, 'Destination display must be at least 3 characters')
     .required(),

--- a/src/features/plan-trip/model/carPoolingTripDataSchema.tsx
+++ b/src/features/plan-trip/model/carPoolingTripDataSchema.tsx
@@ -54,9 +54,7 @@ export const carPoolingTripDataSchema = Yup.object({
     .typeError('Must be a number')
     .integer('Must be an integer')
     .min(0, 'Must be zero or a positive integer')
-    .nullable()
-    .defined()
-    .transform((value, original) => (original === '' ? null : value)),
+    .required(),
   contactUrl: Yup.string()
     .url('Must be a valid URL')
     .nullable()

--- a/src/features/plan-trip/util/mapToFormData.tsx
+++ b/src/features/plan-trip/util/mapToFormData.tsx
@@ -22,7 +22,6 @@ const mapToFormData = (journey: Extrajourney): CarPoolingTripDataFormData => {
     id: journey.id,
     lineRef: journey.estimatedVehicleJourney.lineRef,
     estimatedVehicleJourneyCode: journey.estimatedVehicleJourney.estimatedVehicleJourneyCode,
-    lineName: journey.estimatedVehicleJourney.publishedLineName,
     destinationDisplay: firstCall.destinationDisplay,
     departureStopName: firstCall.stopPointName,
     departureDatetime: dayjs(firstCall.aimedDepartureTime),

--- a/src/features/plan-trip/util/mapToFormData.tsx
+++ b/src/features/plan-trip/util/mapToFormData.tsx
@@ -44,7 +44,7 @@ const mapToFormData = (journey: Extrajourney): CarPoolingTripDataFormData => {
             dayjs(lastCall.aimedArrivalTime),
             'minutes'
           )
-        : null,
+        : 5,
     contactUrl: journey.estimatedVehicleJourney.publicContact?.url ?? null,
     totalCapacity: firstCall.expectedDepartureCapacities?.[0]?.totalCapacity ?? null,
     onboardCount: firstCall.expectedDepartureOccupancy?.[0]?.onboardCount ?? null,

--- a/src/features/plan-trip/util/mapToFormData.tsx
+++ b/src/features/plan-trip/util/mapToFormData.tsx
@@ -22,7 +22,8 @@ const mapToFormData = (journey: Extrajourney): CarPoolingTripDataFormData => {
     id: journey.id,
     lineRef: journey.estimatedVehicleJourney.lineRef,
     estimatedVehicleJourneyCode: journey.estimatedVehicleJourney.estimatedVehicleJourneyCode,
-    destinationDisplay: firstCall.destinationDisplay,
+    departureDestinationDisplay: firstCall.destinationDisplay,
+    destinationDestinationDisplay: lastCall.destinationDisplay,
     departureStopName: firstCall.stopPointName,
     departureDatetime: dayjs(firstCall.aimedDepartureTime),
     departureFlexibleStop: flexAreaToPosition(

--- a/src/features/planned-trips/CarPoolingTrips.tsx
+++ b/src/features/planned-trips/CarPoolingTrips.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import type { Extrajourney } from '../../shared/model/Extrajourney.tsx';
 import { useQueryExtraJourney } from './hooks/useQueryExtraJourney.tsx';
 import Button from '@mui/material/Button';
 import { useNavigate } from 'react-router-dom';
-import { Box, Typography } from '@mui/material';
+import { Box, Checkbox, FormControlLabel, Stack, Typography } from '@mui/material';
 import dayjs from 'dayjs';
 
 const formatMinuteResolution = (value: string | null | undefined) =>
@@ -15,6 +15,8 @@ export default function CarPoolingTrips() {
   const [plannedTrips, setPlannedTrips] = useState<Extrajourney[] | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showPastArrivals, setShowPastArrivals] = useState(false);
+  const [showExpired, setShowExpired] = useState(false);
 
   const queryExtraJourneys = useQueryExtraJourney();
 
@@ -30,6 +32,24 @@ export default function CarPoolingTrips() {
       });
   }, [queryExtraJourneys]);
 
+  const rows = useMemo(() => {
+    if (!plannedTrips) return plannedTrips;
+    const now = Date.now();
+    return plannedTrips.filter(trip => {
+      if (!showPastArrivals) {
+        const calls = trip.estimatedVehicleJourney.estimatedCalls?.estimatedCall;
+        const latestExpected =
+          calls && calls.length > 0 ? calls[calls.length - 1].latestExpectedArrivalTime : null;
+        if (latestExpected && dayjs(latestExpected).valueOf() < now) return false;
+      }
+      if (!showExpired) {
+        const expiresAt = trip.estimatedVehicleJourney.expiresAtEpochMs;
+        if (expiresAt && expiresAt < now) return false;
+      }
+      return true;
+    });
+  }, [plannedTrips, showPastArrivals, showExpired]);
+
   if (loading) {
     return <div className="alert alert-info">Loading...</div>;
   }
@@ -37,8 +57,6 @@ export default function CarPoolingTrips() {
   if (error) {
     return <div className="alert alert-danger">{error}</div>;
   }
-
-  const rows = plannedTrips;
 
   const columns: GridColDef[] = [
     {
@@ -168,6 +186,26 @@ export default function CarPoolingTrips() {
 
   return (
     <div>
+      <Stack direction="row" spacing={2} sx={{ mb: 1 }}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={showPastArrivals}
+              onChange={event => setShowPastArrivals(event.target.checked)}
+            />
+          }
+          label="Show completed trips"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={showExpired}
+              onChange={event => setShowExpired(event.target.checked)}
+            />
+          }
+          label="Show expired trips"
+        />
+      </Stack>
       <DataGrid rows={rows} columns={columns} />
     </div>
   );

--- a/src/features/planned-trips/CarPoolingTrips.tsx
+++ b/src/features/planned-trips/CarPoolingTrips.tsx
@@ -86,20 +86,6 @@ export default function CarPoolingTrips() {
       ),
     },
     {
-      field: 'lineNameValue',
-      headerName: 'Line name',
-      flex: 1,
-      valueGetter: (_value: string, row: Extrajourney) =>
-        row.estimatedVehicleJourney.publishedLineName,
-    },
-    {
-      field: 'destinationDisplayValue',
-      headerName: 'Destination display',
-      flex: 1,
-      valueGetter: (_value: string, row: Extrajourney) =>
-        row.estimatedVehicleJourney.estimatedCalls?.estimatedCall[0].destinationDisplay,
-    },
-    {
       field: 'departureStopName',
       headerName: 'Departure stop name',
       flex: 1,

--- a/src/features/planned-trips/CarPoolingTrips.tsx
+++ b/src/features/planned-trips/CarPoolingTrips.tsx
@@ -208,7 +208,13 @@ export default function CarPoolingTrips() {
           Showing {rows?.length ?? 0} of {plannedTrips?.length ?? 0} trips
         </Typography>
       </Stack>
-      <DataGrid rows={rows} columns={columns} />
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        initialState={{
+          sorting: { sortModel: [{ field: 'departureTimeName', sort: 'desc' }] },
+        }}
+      />
     </div>
   );
 }

--- a/src/features/planned-trips/CarPoolingTrips.tsx
+++ b/src/features/planned-trips/CarPoolingTrips.tsx
@@ -43,8 +43,7 @@ export default function CarPoolingTrips() {
         if (latestExpected && dayjs(latestExpected).valueOf() < now) return false;
       }
       if (!showExpired) {
-        const expiresAt = trip.estimatedVehicleJourney.expiresAtEpochMs;
-        if (expiresAt && expiresAt < now) return false;
+        if (trip.estimatedVehicleJourney.expiresAtEpochMs < now) return false;
       }
       return true;
     });
@@ -186,7 +185,7 @@ export default function CarPoolingTrips() {
 
   return (
     <div>
-      <Stack direction="row" spacing={2} sx={{ mb: 1 }}>
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1 }}>
         <FormControlLabel
           control={
             <Checkbox
@@ -205,6 +204,9 @@ export default function CarPoolingTrips() {
           }
           label="Show expired trips"
         />
+        <Typography variant="body2" color="text.secondary">
+          Showing {rows?.length ?? 0} of {plannedTrips?.length ?? 0} trips
+        </Typography>
       </Stack>
       <DataGrid rows={rows} columns={columns} />
     </div>

--- a/src/shared/api/api.tsx
+++ b/src/shared/api/api.tsx
@@ -11,6 +11,7 @@ import type { Config } from '../../contexts/ConfigContext.tsx';
 import type { AuthState } from 'react-oidc-context';
 import prepareCarpoolingFormData from './prepareCarpoolingFormData.tsx';
 import prepareBookingData, { type PassengerBookingData } from './prepareBookingData.tsx';
+import getStreetRoute from './journeyPlannerStreetRoute.tsx';
 import type { CarPoolingTripDataFormData } from '../../features/plan-trip/model/CarPoolingTripDataFormData.tsx';
 import type { AppError } from '../error-message/AppError.tsx';
 import type { Extrajourney } from '../model/Extrajourney.tsx';
@@ -368,6 +369,7 @@ const api = (config: Config, auth?: AuthState) => {
         originalTrip,
         bookingData
       ),
+    getStreetRoute: getStreetRoute(config['journey-planner-api'] as string),
   };
 };
 

--- a/src/shared/api/journeyPlannerStreetRoute.tsx
+++ b/src/shared/api/journeyPlannerStreetRoute.tsx
@@ -1,0 +1,47 @@
+import { ApolloClient, gql, HttpLink, InMemoryCache } from '@apollo/client';
+import type { Position } from 'geojson';
+
+export interface StreetRouteResult {
+  expectedStartTime: string;
+  expectedEndTime: string;
+  duration: number;
+  distance: number;
+}
+
+const getStreetRoute =
+  (uri: string) =>
+  async (from: Position, to: Position, dateTime: string): Promise<StreetRouteResult | null> => {
+    const client = new ApolloClient({
+      link: new HttpLink({
+        uri,
+        headers: { 'ET-Client-Name': 'entur - deviation-messages' },
+      }),
+      cache: new InMemoryCache(),
+    });
+
+    const query = gql`
+      query StreetRoute($from: Location!, $to: Location!, $dateTime: DateTime, $modes: Modes) {
+        trip(from: $from, to: $to, dateTime: $dateTime, modes: $modes, numTripPatterns: 1) {
+          tripPatterns {
+            expectedStartTime
+            expectedEndTime
+            duration
+            distance
+          }
+        }
+      }
+    `;
+
+    const variables = {
+      from: { coordinates: { latitude: from[1], longitude: from[0] } },
+      to: { coordinates: { latitude: to[1], longitude: to[0] } },
+      dateTime,
+      modes: { directMode: 'car', transportModes: [] },
+    };
+
+    const result = await client.query({ query, variables });
+    const patterns = result.data?.trip?.tripPatterns;
+    return patterns && patterns.length > 0 ? patterns[0] : null;
+  };
+
+export default getStreetRoute;

--- a/src/shared/api/prepareCarpoolingFormData.tsx
+++ b/src/shared/api/prepareCarpoolingFormData.tsx
@@ -68,12 +68,9 @@ function prepareCarpoolingFormData(formData: CarPoolingTripDataFormData): {
               destinationDisplay: formData.destinationDestinationDisplay,
               aimedArrivalTime: formData.destinationDatetime.toISOString(),
               expectedArrivalTime: formData.destinationDatetime.toISOString(),
-              latestExpectedArrivalTime:
-                formData.driverDeviationBudget != null
-                  ? formData.destinationDatetime
-                      .add(formData.driverDeviationBudget, 'minutes')
-                      .toISOString()
-                  : undefined,
+              latestExpectedArrivalTime: formData.destinationDatetime
+                .add(formData.driverDeviationBudget, 'minutes')
+                .toISOString(),
               arrivalBoardingActivity: 'alighting',
               expectedDepartureOccupancy: [
                 {

--- a/src/shared/api/prepareCarpoolingFormData.tsx
+++ b/src/shared/api/prepareCarpoolingFormData.tsx
@@ -41,7 +41,7 @@ function prepareCarpoolingFormData(formData: CarPoolingTripDataFormData): {
               order: 1,
               stopPointRef: 'Mandatory for now', // TODO: Discuss to make optional in a Profile
               stopPointName: formData.departureStopName,
-              destinationDisplay: formData.destinationDisplay,
+              destinationDisplay: formData.departureDestinationDisplay,
               aimedDepartureTime: formData.departureDatetime.toISOString(),
               expectedDepartureTime: formData.departureDatetime.toISOString(),
               departureBoardingActivity: 'boarding',
@@ -65,7 +65,7 @@ function prepareCarpoolingFormData(formData: CarPoolingTripDataFormData): {
               order: 2,
               stopPointRef: 'Mandatory for now', // TODO: Discuss to make optional in a Profile
               stopPointName: formData.destinationStopName,
-              destinationDisplay: formData.destinationDisplay,
+              destinationDisplay: formData.destinationDestinationDisplay,
               aimedArrivalTime: formData.destinationDatetime.toISOString(),
               expectedArrivalTime: formData.destinationDatetime.toISOString(),
               latestExpectedArrivalTime:

--- a/src/shared/api/prepareCarpoolingFormData.tsx
+++ b/src/shared/api/prepareCarpoolingFormData.tsx
@@ -27,7 +27,7 @@ function prepareCarpoolingFormData(formData: CarPoolingTripDataFormData): {
         extraJourney: true,
         vehicleMode: 'bus', // TODO: Needs to add car as vehicle mode
         routeRef: '', // TODO: Mandatory in profile. Unused. Check to see if mandatory in schema.
-        publishedLineName: formData.lineName,
+        publishedLineName: `Carpooling trip ${formData.authority}`,
         groupOfLinesRef: '', // TODO: Mandatory in SIRI profile. Unused. Check to see if mandatory in schema.
         externalLineRef: '', // TODO: Reference back to original line which usually a evj is an replacement for... Check to see if mandatory in schema
         operatorRef: formData.operator,


### PR DESCRIPTION
## Trips page

### `af6417e` — Add filters to hide completed and expired trips
Two checkboxes on the Trips page, both off by default. "Show completed trips" hides rows whose latest-expected arrival time has passed; "Show expired trips" hides rows whose `expiresAtEpochMs` has passed.

### `4182113` — Show filtered/total trip count
Adds a `Showing X of Y trips` caption next to the filters so it's obvious when rows are being hidden. Also removed a redundant nullable guard on `expiresAtEpochMs` in the filter predicate — the field is required on saved `EstimatedVehicleJourney` instances.

### `14a776c` — Default sort = Departure time descending
DataGrid `initialState.sorting.sortModel` set so the most recent trips appear first on page load.

### `793c51b` — Drop Line name and Destination display columns
`publishedLineName` is now derived (`Carpooling trip ${authority}`) and the destination display duplicates info already shown in the stop columns — both columns removed from the grid.

## Plan-trip form

### `9e67412` — Derive publishedLineName, remove lineName form field
`publishedLineName` is hardcoded in `prepareCarpoolingFormData` as `Carpooling trip ${authority}`. The `lineName` form field, its schema rule, default value, Controller block, and round-trip mapping in `mapToFormData` are gone.

### `b68b29f` — Add dividers between trip form sections
Horizontal MUI `<Divider />` between the Departure and Destination sections, and between Destination and the remaining trip-detail fields.

### `0dbabf0` — Split destinationDisplay into per-leg form fields
The single top-level `destinationDisplay` form field is replaced with `departureDestinationDisplay` and `destinationDestinationDisplay`, each rendered at the top of its section (defaults: `"Departure Display"` / `"Destination Display"`). On submit they map to the first and last estimated call's `destinationDisplay`; same on load.

### `e5571d2` — Auto-fill destination arrival via Journey Planner street routing
- New `journeyPlannerStreetRoute.tsx` Apollo client calling JP v3's `trip` query with `modes: { directMode: car, transportModes: [] }` against the `journey-planner-api` config endpoint.
- New `useStreetRoute` hook; wired into the `api(config)` factory as `getStreetRoute`.
- The trip form watches the two stop coordinates and the departure time; whenever all three are set it calls JP and writes the returned `expectedEndTime` into `destinationDatetime`.
- `departureDatetime` now defaults to `dayjs()` (now) on a fresh form; `reset(initialState)` still wins when editing an existing trip.
- Bug fix bundled in: `driverDeviationBudget` is now a required field (default 5 minutes) so `latestExpectedArrivalTime` is always populated on submit. Previously it was nullable; when the user skipped it the field was `undefined`, which meant the Trips-page "completed" filter could never hide those trips.
