### PR TITLE
Replace history on protected-route login to fix back-button trap

### DIFF
--- a/src/features/passenger-booking/PassengerTripBooking.test.tsx
+++ b/src/features/passenger-booking/PassengerTripBooking.test.tsx
@@ -142,12 +142,37 @@ describe('PassengerTripBooking', () => {
   it('pre-populates pickup and dropoff from URL query parameters', async () => {
     queryExtraJourney.mockResolvedValue({ data: { extraJourney: trip } });
 
-    renderAt('/book-trip/ENT:ServiceJourney:1?pickup=59.9139,10.7522&dropoff=60.3913,5.3221');
+    renderAt(
+      '/book-trip/ENT:ServiceJourney:1?from_coordinate=59.9139,10.7522&to_coordinate=60.3913,5.3221'
+    );
 
     await screen.findByText('Carpooling trip ENT:Authority:ENT');
 
     expect(screen.getByDisplayValue('59.913900, 10.752200')).toBeInTheDocument();
     expect(screen.getByDisplayValue('60.391300, 5.322100')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Book Ride' })).toBeEnabled();
+  });
+
+  it('labels the coordinate text fields as "Pickup Coordinates" and "Dropoff Coordinates"', async () => {
+    queryExtraJourney.mockResolvedValue({ data: { extraJourney: trip } });
+
+    renderAt();
+
+    expect(await screen.findByLabelText('Your Pickup Coordinates')).toBeInTheDocument();
+    expect(screen.getByLabelText('Your Dropoff Coordinates')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Your Origin Location')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Your Destination Location')).not.toBeInTheDocument();
+  });
+
+  it('does not surface a pre-selection notice when coordinates are present in the URL', async () => {
+    queryExtraJourney.mockResolvedValue({ data: { extraJourney: trip } });
+
+    renderAt(
+      '/book-trip/ENT:ServiceJourney:1?from_coordinate=59.9139,10.7522&to_coordinate=60.3913,5.3221'
+    );
+
+    await screen.findByText('Carpooling trip ENT:Authority:ENT');
+
+    expect(screen.queryByText(/pre-selected from the shared URL/i)).not.toBeInTheDocument();
   });
 });

--- a/src/features/passenger-booking/PassengerTripBooking.tsx
+++ b/src/features/passenger-booking/PassengerTripBooking.tsx
@@ -74,20 +74,26 @@ export default function PassengerTripBooking() {
     return undefined;
   };
 
-  // Update URL parameters when coordinates change
+  // Update URL parameters when coordinates change. Parameter names and value
+  // format (`lat,lng` with 6-decimal precision) match what OpenTripPlanner's
+  // carpooling module appends to the booking URL so the same link round-trips
+  // between OTP-generated and app-shared URLs.
+  const formatCoordinate = (coords: [number, number]) =>
+    `${coords[1].toFixed(6)},${coords[0].toFixed(6)}`;
+
   const updateURLParams = (pickup?: [number, number], dropoff?: [number, number]) => {
     const newParams = new URLSearchParams(searchParams);
 
     if (pickup) {
-      newParams.set('pickup', `${pickup[1]},${pickup[0]}`); // Store as lat,lng in URL
+      newParams.set('from_coordinate', formatCoordinate(pickup));
     } else {
-      newParams.delete('pickup');
+      newParams.delete('from_coordinate');
     }
 
     if (dropoff) {
-      newParams.set('dropoff', `${dropoff[1]},${dropoff[0]}`); // Store as lat,lng in URL
+      newParams.set('to_coordinate', formatCoordinate(dropoff));
     } else {
-      newParams.delete('dropoff');
+      newParams.delete('to_coordinate');
     }
 
     setSearchParams(newParams, { replace: true });
@@ -113,8 +119,8 @@ export default function PassengerTripBooking() {
 
   // Initialize form with URL parameters
   useEffect(() => {
-    const pickupParam = searchParams.get('pickup');
-    const dropoffParam = searchParams.get('dropoff');
+    const pickupParam = searchParams.get('from_coordinate');
+    const dropoffParam = searchParams.get('to_coordinate');
 
     const pickupCoords = parseCoordinatesFromURL(pickupParam);
     const dropoffCoords = parseCoordinatesFromURL(dropoffParam);
@@ -446,7 +452,7 @@ export default function PassengerTripBooking() {
               <Stack spacing={3}>
                 <TextField
                   fullWidth
-                  label="Your Origin Location"
+                  label="Your Pickup Coordinates"
                   placeholder="Enter pickup address or location"
                   value={bookingData.origin}
                   onChange={handleInputChange('origin')}
@@ -455,7 +461,7 @@ export default function PassengerTripBooking() {
 
                 <TextField
                   fullWidth
-                  label="Your Destination Location"
+                  label="Your Dropoff Coordinates"
                   placeholder="Enter drop-off address or location"
                   value={bookingData.destination}
                   onChange={handleInputChange('destination')}
@@ -582,13 +588,6 @@ export default function PassengerTripBooking() {
                 View the trip route and click the buttons below to select your pickup and drop-off
                 locations on the map.
               </Typography>
-              {(searchParams.has('pickup') || searchParams.has('dropoff')) && (
-                <Alert severity="info" sx={{ mb: 2 }}>
-                  <Typography variant="body2">
-                    📍 Locations have been pre-selected from the shared URL
-                  </Typography>
-                </Alert>
-              )}
               <PassengerBookingMap
                 trip={trip}
                 onPickupLocationSelect={handlePickupLocationSelect}

--- a/src/features/passenger-booking/components/PassengerBookingMap.tsx
+++ b/src/features/passenger-booking/components/PassengerBookingMap.tsx
@@ -14,6 +14,7 @@ import { mapStyle } from '../../../shared/util/mapStyle.ts';
 import type { Extrajourney } from '../../../shared/model/Extrajourney';
 import type { Feature, LineString, Point } from 'geojson';
 import loadFeatureFromFlexArea from '../../plan-trip/util/loadFeatureFromFlexArea.tsx';
+import { shortestPathThrough } from '../util/shortestPath.tsx';
 
 interface PassengerBookingMapProps {
   trip: Extrajourney | null;
@@ -61,16 +62,30 @@ export default function PassengerBookingMap({
     return areas;
   }, [trip, tripData]);
 
-  // Create route line between stops
+  // Route line drawn on the map. Origin and destination stay pinned to the
+  // first and last stops; the trip's intermediate stops plus any selected
+  // pickup/dropoff are reordered to form the shortest path between them.
+  // Without a pickup or dropoff we keep the driver's stop order untouched.
   const createRouteLineString = useCallback((): Feature<LineString> | null => {
     if (!trip || tripData.length < 2) return null;
 
     const flexAreas = getFlexibleAreas();
     if (flexAreas.length < 2) return null;
 
-    const coordinates: [number, number][] = flexAreas.map(
-      area => area.geometry.coordinates as [number, number]
-    );
+    const originCoord = flexAreas[0].geometry.coordinates as [number, number];
+    const destinationCoord = flexAreas[flexAreas.length - 1].geometry.coordinates as [
+      number,
+      number,
+    ];
+
+    const coordinates: [number, number][] =
+      pickupLocation || dropoffLocation
+        ? shortestPathThrough(originCoord, destinationCoord, [
+            ...flexAreas.slice(1, -1).map(area => area.geometry.coordinates as [number, number]),
+            ...(pickupLocation ? [pickupLocation] : []),
+            ...(dropoffLocation ? [dropoffLocation] : []),
+          ])
+        : flexAreas.map(area => area.geometry.coordinates as [number, number]);
 
     return {
       type: 'Feature',
@@ -80,7 +95,7 @@ export default function PassengerBookingMap({
         coordinates,
       },
     };
-  }, [trip, tripData, getFlexibleAreas]);
+  }, [trip, tripData, getFlexibleAreas, pickupLocation, dropoffLocation]);
 
   // Handle map clicks for location selection
   const handleMapClick = useCallback(
@@ -101,28 +116,32 @@ export default function PassengerBookingMap({
     [selectionMode, onPickupLocationSelect, onDropoffLocationSelect]
   );
 
-  // Fit map to show the entire trip route
+  // Fit map to show the trip route plus any selected pickup/dropoff. Without
+  // this the view stays anchored on the driver's origin/destination and a
+  // pickup or dropoff outside the trip's bounding box ends up off-screen.
   useEffect(() => {
     if (!isMapReady || !mapRef.current || !trip) return;
 
     const flexAreas = getFlexibleAreas();
     if (flexAreas.length === 0) return;
 
-    // Calculate bounds to include all flexible areas
+    const points: [number, number][] = flexAreas.map(
+      area => area.geometry.coordinates as [number, number]
+    );
+    if (pickupLocation) points.push(pickupLocation);
+    if (dropoffLocation) points.push(dropoffLocation);
+
     let minLng = Infinity,
       maxLng = -Infinity;
     let minLat = Infinity,
       maxLat = -Infinity;
-
-    flexAreas.forEach(area => {
-      const [lng, lat] = area.geometry.coordinates;
+    points.forEach(([lng, lat]) => {
       minLng = Math.min(minLng, lng);
       maxLng = Math.max(maxLng, lng);
       minLat = Math.min(minLat, lat);
       maxLat = Math.max(maxLat, lat);
     });
 
-    // Add padding
     const padding = 0.01;
     mapRef.current.fitBounds(
       [
@@ -131,7 +150,7 @@ export default function PassengerBookingMap({
       ],
       { padding: 40, duration: 1000 }
     );
-  }, [isMapReady, trip, getFlexibleAreas]);
+  }, [isMapReady, trip, getFlexibleAreas, pickupLocation, dropoffLocation]);
 
   const flexibleAreas = getFlexibleAreas();
   const routeLine = createRouteLineString();

--- a/src/features/passenger-booking/util/shortestPath.test.tsx
+++ b/src/features/passenger-booking/util/shortestPath.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { haversineKm, shortestPathThrough, type LngLat } from './shortestPath';
+
+// Coordinates used throughout the tests are [lng, lat].
+const OSLO: LngLat = [10.7522, 59.9139];
+const BERGEN: LngLat = [5.3221, 60.3913];
+const TRONDHEIM: LngLat = [10.3951, 63.4305];
+const STAVANGER: LngLat = [5.7331, 58.969];
+
+describe('haversineKm', () => {
+  it('returns 0 for the same point', () => {
+    expect(haversineKm(OSLO, OSLO)).toBe(0);
+  });
+
+  it('is symmetric', () => {
+    expect(haversineKm(OSLO, BERGEN)).toBeCloseTo(haversineKm(BERGEN, OSLO), 9);
+  });
+
+  it('matches the known great-circle distance between Oslo and Bergen (~308 km)', () => {
+    // Reference value from standard great-circle calculators: ~308 km.
+    expect(haversineKm(OSLO, BERGEN)).toBeGreaterThan(300);
+    expect(haversineKm(OSLO, BERGEN)).toBeLessThan(316);
+  });
+
+  it('handles points across larger latitudes (Oslo→Trondheim ~392 km)', () => {
+    expect(haversineKm(OSLO, TRONDHEIM)).toBeGreaterThan(385);
+    expect(haversineKm(OSLO, TRONDHEIM)).toBeLessThan(400);
+  });
+});
+
+describe('shortestPathThrough', () => {
+  it('returns just [origin, destination] when there are no middle points', () => {
+    expect(shortestPathThrough(OSLO, BERGEN, [])).toEqual([OSLO, BERGEN]);
+  });
+
+  it('keeps the lone middle point between origin and destination', () => {
+    const pickup: LngLat = [10.5, 60.0];
+    expect(shortestPathThrough(OSLO, BERGEN, [pickup])).toEqual([OSLO, pickup, BERGEN]);
+  });
+
+  it('orders two middle points so the closer one to origin comes first', () => {
+    // nearOrigin sits a hair north of Oslo; nearDestination sits a hair east of Bergen.
+    const nearOrigin: LngLat = [10.7522, 60.0];
+    const nearDestination: LngLat = [5.5, 60.3913];
+
+    // Pass them in the deliberately bad order to force the function to reorder.
+    const path = shortestPathThrough(OSLO, BERGEN, [nearDestination, nearOrigin]);
+
+    expect(path).toEqual([OSLO, nearOrigin, nearDestination, BERGEN]);
+  });
+
+  it('does not move origin or destination, regardless of which middle points are closer', () => {
+    // Throw a point that sits much closer to BERGEN than to OSLO into the middle —
+    // origin and destination must still be the bookends.
+    const closeToBergen: LngLat = [5.4, 60.39];
+    const closeToOslo: LngLat = [10.76, 59.92];
+    const path = shortestPathThrough(OSLO, BERGEN, [closeToBergen, closeToOslo]);
+
+    expect(path[0]).toEqual(OSLO);
+    expect(path[path.length - 1]).toEqual(BERGEN);
+    expect(path).toHaveLength(4);
+  });
+
+  it('finds the optimal ordering for several middle points', () => {
+    // Origin = Oslo, destination = Bergen. Middle = Trondheim (far north) and
+    // Stavanger (far southwest). Any path passing through both must hit one
+    // before the other; the optimum depends on geometry — we just assert that
+    // the returned ordering achieves the minimum cost across all permutations.
+    const middle: LngLat[] = [TRONDHEIM, STAVANGER];
+    const result = shortestPathThrough(OSLO, BERGEN, middle);
+
+    // Compute the cost of every permutation and confirm the result matches the minimum.
+    const candidates: LngLat[][] = [
+      [OSLO, TRONDHEIM, STAVANGER, BERGEN],
+      [OSLO, STAVANGER, TRONDHEIM, BERGEN],
+    ];
+    const cost = (path: LngLat[]) =>
+      path.slice(1).reduce((acc, p, i) => acc + haversineKm(path[i], p), 0);
+    const minCost = Math.min(...candidates.map(cost));
+
+    expect(cost(result)).toBeCloseTo(minCost, 9);
+  });
+
+  it('reorders three middle points to minimise total distance', () => {
+    // A small "stops along a corridor" scenario: passing them in scrambled order
+    // should produce the natural left-to-right ordering.
+    const origin: LngLat = [0, 0];
+    const destination: LngLat = [10, 0];
+    const a: LngLat = [2, 0];
+    const b: LngLat = [5, 0];
+    const c: LngLat = [8, 0];
+
+    const result = shortestPathThrough(origin, destination, [c, a, b]);
+    expect(result).toEqual([origin, a, b, c, destination]);
+  });
+
+  it('does not mutate the caller-provided middle array', () => {
+    const middle: LngLat[] = [TRONDHEIM, STAVANGER];
+    const snapshot: LngLat[] = middle.map(p => [...p] as LngLat);
+
+    shortestPathThrough(OSLO, BERGEN, middle);
+
+    expect(middle).toEqual(snapshot);
+  });
+});

--- a/src/features/passenger-booking/util/shortestPath.tsx
+++ b/src/features/passenger-booking/util/shortestPath.tsx
@@ -1,0 +1,62 @@
+// Geometry helpers for ordering pickup/dropoff and the driver's intermediate
+// stops on the booking map. Pure functions — no React, no map runtime — so
+// they're cheap to unit-test in isolation.
+
+export type LngLat = [number, number];
+
+// Great-circle distance in km between two [lng, lat] points. We only need
+// a metric for comparing path lengths, so any monotonic distance would work —
+// Haversine just keeps the math honest across latitudes.
+export const haversineKm = (a: LngLat, b: LngLat): number => {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const [lng1, lat1] = a;
+  const [lng2, lat2] = b;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const s =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  return 2 * 6371 * Math.asin(Math.sqrt(s));
+};
+
+// Shortest Hamiltonian path from `origin` to `destination` through every
+// point in `middle`. Brute-forces permutations — fine because real carpooling
+// trips have a handful of stops, not dozens. The returned array is
+// [origin, ...reordered middle, destination].
+export const shortestPathThrough = (
+  origin: LngLat,
+  destination: LngLat,
+  middle: LngLat[]
+): LngLat[] => {
+  if (middle.length === 0) return [origin, destination];
+
+  let bestCost = Infinity;
+  let bestOrder = middle.slice();
+
+  const order = middle.slice();
+  const pathCost = () => {
+    let cost = haversineKm(origin, order[0]);
+    for (let i = 0; i < order.length - 1; i++) cost += haversineKm(order[i], order[i + 1]);
+    cost += haversineKm(order[order.length - 1], destination);
+    return cost;
+  };
+
+  const permute = (k: number) => {
+    if (k === order.length) {
+      const cost = pathCost();
+      if (cost < bestCost) {
+        bestCost = cost;
+        bestOrder = order.slice();
+      }
+      return;
+    }
+    for (let i = k; i < order.length; i++) {
+      [order[k], order[i]] = [order[i], order[k]];
+      permute(k + 1);
+      [order[k], order[i]] = [order[i], order[k]];
+    }
+  };
+  permute(0);
+
+  return [origin, ...bestOrder, destination];
+};

--- a/src/shared/auth/LoginRedirect.tsx
+++ b/src/shared/auth/LoginRedirect.tsx
@@ -9,7 +9,10 @@ const LoginRedirect = () => {
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
-      login(returnUrl);
+      // Replace history so pressing back from the OIDC login page skips this
+      // protected route — otherwise it would re-trigger the redirect and trap
+      // the user on the login page.
+      login(returnUrl, { replace: true });
     }
   }, [isLoading, isAuthenticated, login, returnUrl]);
 

--- a/src/shared/auth/authUtils.ts
+++ b/src/shared/auth/authUtils.ts
@@ -19,8 +19,14 @@ export interface Auth {
   roleAssignments?: string[] | null;
   getAccessToken: () => Promise<string>;
   logout: ({ returnTo }: { returnTo?: string }) => Promise<void>;
-  /** Starts the OIDC login flow. `returnUrl` is the in-app path to return to afterwards. */
-  login: (returnUrl?: string) => Promise<void>;
+  /**
+   * Starts the OIDC login flow. `returnUrl` is the in-app path to return to
+   * afterwards. Pass `{ replace: true }` to replace the current history entry
+   * instead of pushing — used by protected routes so pressing back from the
+   * OIDC login page skips the protected URL (which would otherwise re-trigger
+   * the redirect and trap the user on the login page).
+   */
+  login: (returnUrl?: string, options?: { replace?: boolean }) => Promise<void>;
 }
 
 export const useAuth = (): Auth => {
@@ -49,13 +55,13 @@ export const useAuth = (): Auth => {
   );
 
   const login = useCallback(
-    (returnUrl?: string) => {
+    (returnUrl?: string, options?: { replace?: boolean }) => {
       if (returnUrl) {
         sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, returnUrl);
       }
       // Always use the registered redirect_uri configured on the AuthProvider;
       // passing an arbitrary current URL would be rejected as a callback mismatch.
-      return signinRedirect();
+      return signinRedirect(options?.replace ? { redirectMethod: 'replace' } : undefined);
     },
     [signinRedirect]
   );


### PR DESCRIPTION
Why: pressing back from the OIDC login page would re-trigger the redirect and strand the user on the login page.