### PR TITLE
Multi-tenant carpooling: codespace-scoped roles, fan-out trip listing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ export default function App() {
                         element={<ProtectedRoute element={<CarPoolingTrip />} />}
                       />
                       <Route
-                        path="/plan-trip/:id"
+                        path="/plan-trip/:codespace/:id"
                         element={<ProtectedRoute element={<CarPoolingTrip />} />}
                       />
                       <Route
@@ -83,7 +83,7 @@ export default function App() {
                         element={<ProtectedRoute element={<CarPoolingTrips />} />}
                       />
                       <Route
-                        path="/book-trip/:tripId"
+                        path="/book-trip/:codespace/:tripId"
                         element={<ProtectedRoute element={<PassengerTripBooking />} />}
                       />
                     </Routes>

--- a/src/features/passenger-booking/PassengerTripBooking.test.tsx
+++ b/src/features/passenger-booking/PassengerTripBooking.test.tsx
@@ -16,6 +16,15 @@ vi.mock('./hooks/useBookPassengerRide', () => ({
   useBookPassengerRide: () => bookPassengerRide,
 }));
 
+// The component looks up the trip's authority via the codespace from the URL.
+// Provide a matching entry so the trip query and booking submission proceed.
+vi.mock('../../shared/hooks/useAuthorities', () => ({
+  useAuthorities: () => ({
+    authorities: [{ id: 'ENT:Authority:ENT', name: 'Entur' }],
+    allowedCodespaces: [{ id: 'ENT', permissions: ['ADMIN_CARPOOLING_DATA'] }],
+  }),
+}));
+
 // Stub the map: replace it with two buttons that invoke the location-select callbacks.
 // This keeps the test off of maplibre/GL while still exercising the props contract.
 vi.mock('./components/PassengerBookingMap', () => ({
@@ -62,8 +71,8 @@ const trip: Extrajourney = {
   },
 } as unknown as Extrajourney;
 
-const renderAt = (path = '/book-trip/ENT:ServiceJourney:1') =>
-  renderWithRouter(<PassengerTripBooking />, { path, route: '/book-trip/:tripId' });
+const renderAt = (path = '/book-trip/ENT/ENT:ServiceJourney:1') =>
+  renderWithRouter(<PassengerTripBooking />, { path, route: '/book-trip/:codespace/:tripId' });
 
 describe('PassengerTripBooking', () => {
   it('shows a loading state while the trip query is pending', () => {
@@ -111,8 +120,9 @@ describe('PassengerTripBooking', () => {
     await user.click(screen.getByRole('button', { name: 'Book Ride' }));
 
     await waitFor(() => expect(bookPassengerRide).toHaveBeenCalledTimes(1));
-    const [submittedTrip, payload] = bookPassengerRide.mock.calls[0];
+    const [submittedTrip, payload, submittedAuthority] = bookPassengerRide.mock.calls[0];
     expect(submittedTrip).toBe(trip);
+    expect(submittedAuthority).toBe('ENT:Authority:ENT');
     expect(payload).toMatchObject({
       tripId: 'ENT:ServiceJourney:1',
       pickupCoordinates: [10.7522, 59.9139],
@@ -143,7 +153,7 @@ describe('PassengerTripBooking', () => {
     queryExtraJourney.mockResolvedValue({ data: { extraJourney: trip } });
 
     renderAt(
-      '/book-trip/ENT:ServiceJourney:1?from_coordinate=59.9139,10.7522&to_coordinate=60.3913,5.3221'
+      '/book-trip/ENT/ENT:ServiceJourney:1?from_coordinate=59.9139,10.7522&to_coordinate=60.3913,5.3221'
     );
 
     await screen.findByText('Carpooling trip ENT:Authority:ENT');
@@ -168,7 +178,7 @@ describe('PassengerTripBooking', () => {
     queryExtraJourney.mockResolvedValue({ data: { extraJourney: trip } });
 
     renderAt(
-      '/book-trip/ENT:ServiceJourney:1?from_coordinate=59.9139,10.7522&to_coordinate=60.3913,5.3221'
+      '/book-trip/ENT/ENT:ServiceJourney:1?from_coordinate=59.9139,10.7522&to_coordinate=60.3913,5.3221'
     );
 
     await screen.findByText('Carpooling trip ENT:Authority:ENT');

--- a/src/features/passenger-booking/PassengerTripBooking.tsx
+++ b/src/features/passenger-booking/PassengerTripBooking.tsx
@@ -26,6 +26,7 @@ import type { Extrajourney } from '../../shared/model/Extrajourney';
 import { useQueryExtraJourney } from '../plan-trip/hooks/useQueryOneExtraJourney';
 import PassengerBookingMap from './components/PassengerBookingMap';
 import { useBookPassengerRide } from './hooks/useBookPassengerRide';
+import { useAuthorities } from '../../shared/hooks/useAuthorities';
 
 interface PassengerBookingFormData {
   origin: string;
@@ -39,7 +40,19 @@ interface PassengerBookingFormData {
 }
 
 export default function PassengerTripBooking() {
-  const { tripId } = useParams<{ tripId: string }>();
+  const { codespace, tripId } = useParams<{ codespace: string; tripId: string }>();
+  const { authorities, allowedCodespaces } = useAuthorities();
+  const tripAuthority = codespace
+    ? authorities.find(a => a.id.startsWith(`${codespace}:`))
+    : undefined;
+  // Booking writes the trip back, so requires adminCarpoolingData on the
+  // codespace — surface that as a disabled button rather than letting the
+  // user fill in the form and hit a 403 on submit.
+  const canBook =
+    !!codespace &&
+    !!allowedCodespaces
+      .find(c => c.id === codespace)
+      ?.permissions.includes('ADMIN_CARPOOLING_DATA');
   const [searchParams, setSearchParams] = useSearchParams();
   const [trip, setTrip] = useState<Extrajourney | null>(null);
   const [loading, setLoading] = useState(true);
@@ -100,9 +113,9 @@ export default function PassengerTripBooking() {
   };
 
   useEffect(() => {
-    if (!tripId) return;
+    if (!tripId || !codespace || !tripAuthority) return;
 
-    queryExtraJourney('ENT', 'ENT:Authority:ENT', tripId)
+    queryExtraJourney(codespace, tripAuthority.id, tripId)
       .then(response => {
         if (response.error) {
           setError('Failed to load trip details');
@@ -115,7 +128,7 @@ export default function PassengerTripBooking() {
         setError('Failed to load trip details');
         setLoading(false);
       });
-  }, [tripId, queryExtraJourney]);
+  }, [codespace, tripAuthority, tripId, queryExtraJourney]);
 
   // Initialize form with URL parameters
   useEffect(() => {
@@ -213,6 +226,11 @@ export default function PassengerTripBooking() {
       return;
     }
 
+    if (!tripAuthority) {
+      setBookingError('Could not resolve the authority for this trip');
+      return;
+    }
+
     setIsBookingInProgress(true);
     setBookingError(null);
 
@@ -227,7 +245,7 @@ export default function PassengerTripBooking() {
         passengerDeviationBudget: bookingData.passengerDeviationBudget,
       };
 
-      const result = await bookPassengerRide(trip, bookingPayload);
+      const result = await bookPassengerRide(trip, bookingPayload, tripAuthority.id);
 
       if (result.error) {
         setBookingError(result.error.message);
@@ -536,6 +554,14 @@ export default function PassengerTripBooking() {
                   </Alert>
                 )}
 
+                {!canBook && (
+                  <Alert severity="info">
+                    <Typography variant="body2">
+                      You don&apos;t have permission to book rides in this codespace.
+                    </Typography>
+                  </Alert>
+                )}
+
                 <Box display="flex" gap={2} flexWrap="wrap">
                   <Button
                     variant="outlined"
@@ -548,6 +574,7 @@ export default function PassengerTripBooking() {
                     variant="contained"
                     onClick={handleBookRide}
                     disabled={
+                      !canBook ||
                       !bookingData.pickupCoordinates ||
                       !bookingData.dropoffCoordinates ||
                       isBookingConfirmed ||

--- a/src/features/passenger-booking/hooks/useBookPassengerRide.tsx
+++ b/src/features/passenger-booking/hooks/useBookPassengerRide.tsx
@@ -13,7 +13,8 @@ export const useBookPassengerRide = () => {
   return useCallback(
     async (
       originalTrip: Extrajourney,
-      bookingData: PassengerBookingData
+      bookingData: PassengerBookingData,
+      authority: string
     ): Promise<{ data?: string; error?: AppError }> => {
       if (!auth.user?.access_token) {
         return {
@@ -26,7 +27,11 @@ export const useBookPassengerRide = () => {
       }
 
       try {
-        const result = await api(config, auth).bookPassengerRide(originalTrip, bookingData)();
+        const result = await api(config, auth).bookPassengerRide(
+          originalTrip,
+          bookingData,
+          authority
+        )();
 
         return result;
       } catch (error) {

--- a/src/features/plan-trip/CarPoolingTrip.tsx
+++ b/src/features/plan-trip/CarPoolingTrip.tsx
@@ -11,13 +11,13 @@ import { useParams } from 'react-router-dom';
 import type { Feature } from 'geojson';
 
 export default function CarPoolingTrip() {
-  const { id } = useParams();
+  const { codespace, id } = useParams();
   // Remount on id change so a fresh plan-trip page loads when switching trips
   // (or from editing back to a blank new trip).
-  return <CarPoolingTripView key={id ?? 'new'} id={id} />;
+  return <CarPoolingTripView key={id ?? 'new'} id={id} codespace={codespace} />;
 }
 
-function CarPoolingTripView({ id }: { id?: string }) {
+function CarPoolingTripView({ id, codespace }: { id?: string; codespace?: string }) {
   const theme = useTheme();
 
   const editableMapRef = useRef<EditableMapHandle>(null);
@@ -64,6 +64,7 @@ function CarPoolingTripView({ id }: { id?: string }) {
       >
         <CarPoolingTripData
           tripId={id}
+          codespace={codespace}
           ref={dataHandle}
           onAddFlexibleStop={() => editableMapRef.current?.drawFeature()}
           onRemoveFlexibleStop={id => editableMapRef.current?.removeFeature(id)}

--- a/src/features/plan-trip/components/CarPoolingTripData.test.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripData.test.tsx
@@ -16,6 +16,16 @@ vi.mock('../hooks/useMutateExtrajourney', () => ({
   useMutateExtrajourney: () => vi.fn(),
 }));
 
+// useAuthorities pairs codespaces to NeTEx authority ids; the component waits
+// for the matching authority before issuing the trip query, so the test needs
+// to supply one. Real lookups go through OIDC + GraphQL.
+vi.mock('../../../shared/hooks/useAuthorities', () => ({
+  useAuthorities: () => ({
+    authorities: [{ id: 'ENT:Authority:ENT', name: 'Entur' }],
+    allowedCodespaces: [{ id: 'ENT', permissions: ['ADMIN_CARPOOLING_DATA'] }],
+  }),
+}));
+
 // Stub the heavy form (MUI fields, date pickers, schema). The reset behaviour
 // lives in CarPoolingTripData, so we only need a way to fire onResetCallback
 // and observe whether a trip was loaded.
@@ -36,7 +46,6 @@ const TRIP_ID = 'ENT:ServiceJourney:42';
 // through the real SIRI mapper so the flexible areas decode back into features.
 const journeyFixture = (): Extrajourney => {
   const form: CarPoolingTripDataFormData = {
-    codespace: 'ENT',
     authority: 'ENT:Authority:ENT',
     operator: 'ENT:Operator:1',
     id: TRIP_ID,
@@ -78,7 +87,7 @@ describe('CarPoolingTripData reset behaviour', () => {
     queryOneExtraJourney.mockResolvedValue({ data: { extraJourney: journeyFixture() } });
     const props = mapCallbacks();
 
-    renderWithRouter(<CarPoolingTripData tripId={TRIP_ID} {...props} />);
+    renderWithRouter(<CarPoolingTripData tripId={TRIP_ID} codespace="ENT" {...props} />);
 
     // Initial load draws the trip's stops onto the map.
     await waitFor(() => expect(props.loadedFlexibleStop).toHaveBeenCalledTimes(1));

--- a/src/features/plan-trip/components/CarPoolingTripData.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripData.tsx
@@ -20,6 +20,7 @@ import Snackbar from '@mui/material/Snackbar';
 import MuiAlert from '@mui/material/Alert';
 import loadFeatureFromFlexArea from '../util/loadFeatureFromFlexArea.tsx';
 import mapToFormData from '../util/mapToFormData.tsx';
+import { useAuthorities } from '../../../shared/hooks/useAuthorities.tsx';
 
 const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(props, ref) {
   return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
@@ -34,6 +35,7 @@ interface SnackbarState {
 }
 export interface CarPoolingTripDataProps {
   tripId?: string;
+  codespace?: string;
   onAddFlexibleStop: () => void;
   onZoomToFeature: (id: string) => void;
   onZoomToAllFeatures: () => void;
@@ -58,10 +60,12 @@ const CarPoolingTripData = forwardRef<CarPoolingTripDataHandle, CarPoolingTripDa
       onZoomToFeature,
       onZoomToAllFeatures,
       tripId,
+      codespace,
       loadedFlexibleStop,
       onDepartureStopChange,
       onArrivalStopChange,
     } = stops;
+    const { authorities } = useAuthorities();
     const [snackbar, setSnackbar] = useState<SnackbarState>({
       open: false,
       message: '',
@@ -168,13 +172,17 @@ const CarPoolingTripData = forwardRef<CarPoolingTripDataHandle, CarPoolingTripDa
 
     useEffect(() => {
       const loadInitialState = (id?: string) => {
-        if (initializing.current || !id) return;
+        if (initializing.current || !id || !codespace) return;
+        // Wait for the authority list before issuing the query — we need the
+        // authority id matching the codespace from the URL, not a fabricated one.
+        const authority = authorities.find(a => a.id.startsWith(`${codespace}:`));
+        if (!authority) return;
         initializing.current = true;
-        queryOneExtraJourney('ENT', 'ENT:Authority:ENT', id)
+        queryOneExtraJourney(codespace, authority.id, id)
           .then(result => {
             if (result.data?.extraJourney) {
               const journey = result.data.extraJourney as Extrajourney;
-              const state = mapToFormData(journey);
+              const state = mapToFormData(journey, authority.id);
               setInitialState(state);
               setTripData(journey);
               loadStopsFromJourney(journey);
@@ -186,7 +194,7 @@ const CarPoolingTripData = forwardRef<CarPoolingTripDataHandle, CarPoolingTripDa
       };
       setCurrentTripId(tripId);
       loadInitialState(tripId);
-    }, [loadStopsFromJourney, queryOneExtraJourney, tripId]);
+    }, [authorities, codespace, loadStopsFromJourney, queryOneExtraJourney, tripId]);
 
     useImperativeHandle(
       ref,

--- a/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
@@ -65,15 +65,20 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     drawingStopsAllowed,
     tripData,
   } = props;
-  const { authorities } = useAuthorities();
+  // The form drives mutations (createOrUpdateExtrajourney), so restrict the
+  // authority dropdown to codespaces where the user actually has write rights.
+  // Without this filter, a view-only user would see authorities they can't
+  // submit to and only learn of the rejection on a 403 from the server.
+  const { adminAuthorities: authorities } = useAuthorities();
   const operators = useOperators();
 
   // New trips get a client-generated id so the booking URL (this app's
-  // /book-trip/{id} page) can be prefilled before the trip is saved; the
-  // backend upserts at the supplied id. When editing, reset(initialState)
-  // replaces both with the existing trip's values.
+  // /book-trip/{codespace}/{id} page) can be prefilled before the trip is
+  // saved; the backend upserts at the supplied id. The codespace isn't known
+  // until the authority is selected, so the URL is filled in by the effect
+  // below once that happens. When editing, reset(initialState) replaces both
+  // with the existing trip's values.
   const newTripId = useMemo(() => uuidv4(), []);
-  const defaultBookingUrl = `${window.location.origin}/book-trip/${newTripId}`;
 
   const {
     handleSubmit,
@@ -88,7 +93,6 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     resolver: yupResolver(carPoolingTripDataSchema) as Resolver<CarPoolingTripDataFormData>,
     mode: 'onBlur', // or "onChange", depending on UX preference
     defaultValues: {
-      codespace: 'ENT', // TODO fix hardcoding
       authority: '',
       operator: '',
       id: newTripId,
@@ -101,13 +105,14 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
       intermediateCalls: [],
       tripCancellation: false,
       driverDeviationBudget: 15,
-      contactUrl: defaultBookingUrl,
+      contactUrl: null,
       totalCapacity: 5,
       onboardCount: 1,
     },
   });
 
   const authority = watch('authority');
+  const contactUrl = watch('contactUrl');
   const operator = watch('operator');
   const departureFlexibleStop: Position | null = watch('departureFlexibleStop');
   const destinationFlexibleStop: Position | null = watch('destinationFlexibleStop');
@@ -123,7 +128,19 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
 
   useEffect(() => {
     if (authorities.length && !authority) {
-      setValue('authority', authorities[0].id);
+      // Prefer an ENT-prefixed authority when several are available; otherwise
+      // just take the first. New trips default to whichever codespace the user
+      // is most likely to act in.
+      const enturAuthority = authorities.find(a => a.id.startsWith('ENT:'));
+      setValue('authority', (enturAuthority ?? authorities[0]).id);
+    }
+
+    // Fill in the default booking URL once the authority (and therefore the
+    // codespace) is known. Skip if the user has already entered something — we
+    // never want to clobber a manual edit or an edited trip's existing URL.
+    if (authority && !contactUrl) {
+      const codespace = authority.split(':')[0];
+      setValue('contactUrl', `${window.location.origin}/book-trip/${codespace}/${newTripId}`);
     }
 
     if (operators.length && !operator) {
@@ -175,6 +192,8 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     reset,
     authorities,
     authority,
+    contactUrl,
+    newTripId,
     operators,
     operator,
     mapDepartureFlexibleStop,
@@ -455,31 +474,35 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
           <Divider sx={{ mt: 2 }} />
         </Box>
       )}
-      <FormControl fullWidth required error={!!errors.authority} margin="normal">
-        <InputLabel id="authority-label">Authority</InputLabel>
-        <Controller
-          name="authority"
-          control={control}
-          render={({ field }) => {
-            return (
-              <Select {...field} labelId="authority-label" label="Authority">
-                <MenuItem value="" disabled>
-                  <em>Authority</em>
-                </MenuItem>
-                {field.value && !authorities.some(a => a.id === field.value) && (
-                  <MenuItem value={field.value}>{field.value}</MenuItem>
-                )}
-                {authorities.map(authority => (
-                  <MenuItem key={authority.id} value={authority.id}>
-                    {authority.name}
+      {/* Most users have access to a single authority, so showing a single-option
+          dropdown is just noise. When there is more than one we render the picker. */}
+      {authorities.length > 1 && (
+        <FormControl fullWidth required error={!!errors.authority} margin="normal">
+          <InputLabel id="authority-label">Authority</InputLabel>
+          <Controller
+            name="authority"
+            control={control}
+            render={({ field }) => {
+              return (
+                <Select {...field} labelId="authority-label" label="Authority">
+                  <MenuItem value="" disabled>
+                    <em>Authority</em>
                   </MenuItem>
-                ))}
-              </Select>
-            );
-          }}
-        />
-        <FormHelperText>{errors.authority?.message}</FormHelperText>
-      </FormControl>
+                  {field.value && !authorities.some(a => a.id === field.value) && (
+                    <MenuItem value={field.value}>{field.value}</MenuItem>
+                  )}
+                  {authorities.map(authority => (
+                    <MenuItem key={authority.id} value={authority.id}>
+                      {authority.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              );
+            }}
+          />
+          <FormHelperText>{errors.authority?.message}</FormHelperText>
+        </FormControl>
+      )}
       <FormControl fullWidth required error={!!errors.operator} margin="normal">
         <InputLabel id="operator-label">Operator</InputLabel>
         <Controller

--- a/src/features/plan-trip/model/CarPoolingTripDataFormData.tsx
+++ b/src/features/plan-trip/model/CarPoolingTripDataFormData.tsx
@@ -3,7 +3,6 @@ import type { Position } from 'geojson';
 import type { EstimatedCall } from '../../../shared/model/EstimatedCall.tsx';
 
 export type CarPoolingTripDataFormData = {
-  codespace: string;
   authority: string;
   operator: string;
   id?: string;

--- a/src/features/plan-trip/model/carPoolingTripDataSchema.test.tsx
+++ b/src/features/plan-trip/model/carPoolingTripDataSchema.test.tsx
@@ -3,7 +3,6 @@ import dayjs from 'dayjs';
 import { carPoolingTripDataSchema } from './carPoolingTripDataSchema';
 
 const validInput = () => ({
-  codespace: 'ENT',
   authority: 'ENT:Authority:ENT',
   operator: 'ENT:Operator:1',
   departureStopName: 'Oslo S',
@@ -25,15 +24,6 @@ const validInput = () => ({
 describe('carPoolingTripDataSchema', () => {
   it('accepts a fully-populated valid input', async () => {
     await expect(carPoolingTripDataSchema.validate(validInput())).resolves.toBeDefined();
-  });
-
-  it('requires codespace to be exactly 3 characters', async () => {
-    await expect(
-      carPoolingTripDataSchema.validate({ ...validInput(), codespace: 'EN' })
-    ).rejects.toThrow();
-    await expect(
-      carPoolingTripDataSchema.validate({ ...validInput(), codespace: 'ENTX' })
-    ).rejects.toThrow();
   });
 
   it.each(['departureStopName', 'destinationStopName'])(

--- a/src/features/plan-trip/model/carPoolingTripDataSchema.tsx
+++ b/src/features/plan-trip/model/carPoolingTripDataSchema.tsx
@@ -31,7 +31,6 @@ const positionSchema = Yup.mixed<Position>()
 const dateSchema = Yup.mixed<Dayjs>().dayjs('Not a valid date');
 
 export const carPoolingTripDataSchema = Yup.object({
-  codespace: Yup.string().required().length(3),
   authority: Yup.string().required(),
   operator: Yup.string().required(),
   departureStopName: Yup.string()

--- a/src/features/plan-trip/util/mapToFormData.test.tsx
+++ b/src/features/plan-trip/util/mapToFormData.test.tsx
@@ -14,7 +14,6 @@ const toComparable = (form: CarPoolingTripDataFormData) => ({
 describe('mapToFormData (round-trip with prepareCarpoolingFormData)', () => {
   it('round-trips every form field through the SIRI payload', () => {
     const original: CarPoolingTripDataFormData = {
-      codespace: 'ENT',
       authority: 'ENT:Authority:ENT',
       operator: 'ENT:Operator:1',
       id: 'ENT:ServiceJourney:42',
@@ -37,14 +36,13 @@ describe('mapToFormData (round-trip with prepareCarpoolingFormData)', () => {
     };
 
     const payload = prepareCarpoolingFormData(original);
-    const roundTripped = mapToFormData(payload.input);
+    const roundTripped = mapToFormData(payload.input, 'ENT:Authority:ENT');
 
     expect(toComparable(roundTripped)).toEqual(toComparable(original));
   });
 
   it('round-trips cancellation flags on departure and destination', () => {
     const original: CarPoolingTripDataFormData = {
-      codespace: 'ENT',
       authority: 'ENT:Authority:ENT',
       operator: 'ENT:Operator:1',
       id: 'ENT:ServiceJourney:42',
@@ -67,7 +65,7 @@ describe('mapToFormData (round-trip with prepareCarpoolingFormData)', () => {
     };
 
     const payload = prepareCarpoolingFormData(original);
-    const roundTripped = mapToFormData(payload.input);
+    const roundTripped = mapToFormData(payload.input, 'ENT:Authority:ENT');
 
     expect(roundTripped.departureCancellation).toBe(true);
     expect(roundTripped.destinationCancellation).toBe(true);
@@ -75,7 +73,6 @@ describe('mapToFormData (round-trip with prepareCarpoolingFormData)', () => {
 
   it('round-trips tripCancellation through estimatedVehicleJourney.cancellation', () => {
     const original: CarPoolingTripDataFormData = {
-      codespace: 'ENT',
       authority: 'ENT:Authority:ENT',
       operator: 'ENT:Operator:1',
       id: 'ENT:ServiceJourney:42',
@@ -100,13 +97,12 @@ describe('mapToFormData (round-trip with prepareCarpoolingFormData)', () => {
     const payload = prepareCarpoolingFormData(original);
     expect(payload.input.estimatedVehicleJourney.cancellation).toBe(true);
 
-    const roundTripped = mapToFormData(payload.input);
+    const roundTripped = mapToFormData(payload.input, 'ENT:Authority:ENT');
     expect(roundTripped.tripCancellation).toBe(true);
   });
 
   it('preserves intermediate calls and their cancellation flags through round-trip', () => {
     const original: CarPoolingTripDataFormData = {
-      codespace: 'ENT',
       authority: 'ENT:Authority:ENT',
       operator: 'ENT:Operator:1',
       id: 'ENT:ServiceJourney:42',
@@ -152,7 +148,7 @@ describe('mapToFormData (round-trip with prepareCarpoolingFormData)', () => {
     };
 
     const payload = prepareCarpoolingFormData(original);
-    const roundTripped = mapToFormData(payload.input);
+    const roundTripped = mapToFormData(payload.input, 'ENT:Authority:ENT');
 
     expect(roundTripped.intermediateCalls).toHaveLength(2);
     expect(roundTripped.intermediateCalls[0]).toMatchObject({
@@ -167,7 +163,6 @@ describe('mapToFormData (round-trip with prepareCarpoolingFormData)', () => {
 
   it('round-trips when optional numeric/url fields are null', () => {
     const original: CarPoolingTripDataFormData = {
-      codespace: 'ENT',
       authority: 'ENT:Authority:ENT',
       operator: 'ENT:Operator:1',
       id: 'ENT:ServiceJourney:42',
@@ -190,7 +185,7 @@ describe('mapToFormData (round-trip with prepareCarpoolingFormData)', () => {
     };
 
     const payload = prepareCarpoolingFormData(original);
-    const roundTripped = mapToFormData(payload.input);
+    const roundTripped = mapToFormData(payload.input, 'ENT:Authority:ENT');
 
     expect(toComparable(roundTripped)).toEqual(toComparable(original));
   });

--- a/src/features/plan-trip/util/mapToFormData.tsx
+++ b/src/features/plan-trip/util/mapToFormData.tsx
@@ -10,14 +10,13 @@ const flexAreaToPosition = (flexArea: ExpectedFlexibleArea | undefined): Positio
   return feature ? feature.geometry.coordinates : null;
 };
 
-const mapToFormData = (journey: Extrajourney): CarPoolingTripDataFormData => {
+const mapToFormData = (journey: Extrajourney, authority: string): CarPoolingTripDataFormData => {
   const calls = journey.estimatedVehicleJourney.estimatedCalls.estimatedCall;
   const firstCall = calls[0];
   const lastCall = calls[calls.length - 1];
 
   return {
-    codespace: 'ENT',
-    authority: 'ENT:Authority:ENT',
+    authority,
     operator: journey.estimatedVehicleJourney.operatorRef,
     id: journey.id,
     lineRef: journey.estimatedVehicleJourney.lineRef,

--- a/src/features/planned-trips/CarPoolingTrips.test.tsx
+++ b/src/features/planned-trips/CarPoolingTrips.test.tsx
@@ -11,11 +11,21 @@ vi.mock('./hooks/useQueryExtraJourney.tsx', () => ({
   useQueryExtraJourney: () => queryExtraJourneys,
 }));
 
+// useAuthorities drives the fan-out across allowed codespaces; the test pretends
+// the user only has access to ENT so the existing single-tenant assertions hold.
+vi.mock('../../shared/hooks/useAuthorities.tsx', () => ({
+  useAuthorities: () => ({
+    authorities: [{ id: 'ENT:Authority:ENT', name: 'Entur' }],
+    allowedCodespaces: [{ id: 'ENT', permissions: ['ADMIN_CARPOOLING_DATA'] }],
+  }),
+}));
+
 const trip = (overrides: Partial<Extrajourney> = {}): Extrajourney =>
   ({
     id: 'ENT:ServiceJourney:1',
     estimatedVehicleJourney: {
       recordedAtTime: '2026-05-20T09:00:00.000Z',
+      lineRef: 'ENT:CarPooling:trip-1',
       expiresAtEpochMs: new Date('2099-01-01').valueOf(),
       estimatedCalls: {
         estimatedCall: [

--- a/src/features/planned-trips/CarPoolingTrips.tsx
+++ b/src/features/planned-trips/CarPoolingTrips.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import type { Extrajourney } from '../../shared/model/Extrajourney.tsx';
 import { useQueryExtraJourney } from './hooks/useQueryExtraJourney.tsx';
+import { useAuthorities } from '../../shared/hooks/useAuthorities.tsx';
 import Button from '@mui/material/Button';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
@@ -29,8 +30,10 @@ export default function CarPoolingTrips() {
   const [showExpired, setShowExpired] = useState(false);
   const [showHiddenFields, setShowHiddenFields] = useState(false);
   const [savedMessage, setSavedMessage] = useState<string | null>(null);
+  const [failedCodespaces, setFailedCodespaces] = useState<string[]>([]);
 
   const queryExtraJourneys = useQueryExtraJourney();
+  const { authorities } = useAuthorities();
 
   useEffect(() => {
     const message = (location.state as { savedMessage?: string } | null)?.savedMessage;
@@ -42,16 +45,36 @@ export default function CarPoolingTrips() {
   }, [location.state, location.pathname, navigate]);
 
   useEffect(() => {
-    queryExtraJourneys('ENT', 'ENT:Authority:ENT', true)
-      .then(response => {
-        setPlannedTrips(response.data);
+    if (!authorities.length) return;
+    // Fan out across every authority the user has access to and merge the
+    // results. Each trip carries its own codespace in its lineRef, so callers
+    // (edit/book navigation) can identify which tenant a row belongs to.
+    // Track per-codespace failures so we can surface a non-fatal warning rather
+    // than silently returning fewer trips than the user expects.
+    Promise.all(
+      authorities.map(authority =>
+        queryExtraJourneys(authority.id.split(':')[0], authority.id, true)
+      )
+    )
+      .then(responses => {
+        const merged: Extrajourney[] = [];
+        const failed: string[] = [];
+        responses.forEach((response, index) => {
+          if (response.data) {
+            merged.push(...response.data);
+          } else if (response.error) {
+            failed.push(authorities[index].id.split(':')[0]);
+          }
+        });
+        setPlannedTrips(merged);
+        setFailedCodespaces(failed);
         setLoading(false);
       })
-      .catch(error => {
-        setError(error);
+      .catch(err => {
+        setError(err);
         setLoading(false);
       });
-  }, [queryExtraJourneys]);
+  }, [authorities, queryExtraJourneys]);
 
   const rows = useMemo(() => {
     if (!plannedTrips) return plannedTrips;
@@ -85,25 +108,31 @@ export default function CarPoolingTrips() {
       minWidth: 180,
       sortable: false,
       filterable: false,
-      renderCell: params => (
-        <Box>
-          <Button
-            variant="contained"
-            size="small"
-            onClick={() => navigate(`/plan-trip/${params.row.id}`)}
-          >
-            Edit
-          </Button>
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={() => navigate(`/book-trip/${params.row.id}`)}
-            style={{ marginLeft: 8 }}
-          >
-            Book Ride
-          </Button>
-        </Box>
-      ),
+      renderCell: params => {
+        // Codespace is encoded in the trip's lineRef as `<CODESPACE>:CarPooling:<uuid>`.
+        // It identifies which Firestore partition the trip lives in, so it must
+        // be in the URL for the edit/book pages to know which tenant to query.
+        const codespace = params.row.estimatedVehicleJourney.lineRef?.split(':')[0] ?? '';
+        return (
+          <Box>
+            <Button
+              variant="contained"
+              size="small"
+              onClick={() => navigate(`/plan-trip/${codespace}/${params.row.id}`)}
+            >
+              Edit
+            </Button>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => navigate(`/book-trip/${codespace}/${params.row.id}`)}
+              style={{ marginLeft: 8 }}
+            >
+              Book Ride
+            </Button>
+          </Box>
+        );
+      },
     },
     {
       field: 'id',
@@ -219,6 +248,12 @@ export default function CarPoolingTrips() {
 
   return (
     <Box sx={{ width: '100%', maxWidth: 1400, mx: 'auto', p: { xs: 1, sm: 2 } }}>
+      {failedCodespaces.length > 0 && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Could not load trips from: {failedCodespaces.join(', ')}. The list below may be
+          incomplete.
+        </Alert>
+      )}
       <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1 }}>
         <FormControlLabel
           control={

--- a/src/shared/api/api.tsx
+++ b/src/shared/api/api.tsx
@@ -297,7 +297,13 @@ const queryExtraJourney =
   };
 
 const bookPassengerRide =
-  (uri: string, auth: AuthState, originalTrip: Extrajourney, bookingData: PassengerBookingData) =>
+  (
+    uri: string,
+    auth: AuthState,
+    originalTrip: Extrajourney,
+    bookingData: PassengerBookingData,
+    authority: string
+  ) =>
   async (): Promise<{ data?: string; error?: AppError }> => {
     if (!auth.user?.access_token) {
       throw new Error('Access token is missing');
@@ -315,7 +321,7 @@ const bookPassengerRide =
     `;
 
     try {
-      const variables = prepareBookingData(originalTrip, bookingData);
+      const variables = prepareBookingData(originalTrip, bookingData, authority);
 
       const result = await client.mutate({
         mutation,
@@ -362,12 +368,17 @@ const api = (config: Config, auth?: AuthState) => {
         authority,
         showCompletedTrips
       ),
-    bookPassengerRide: (originalTrip: Extrajourney, bookingData: PassengerBookingData) =>
+    bookPassengerRide: (
+      originalTrip: Extrajourney,
+      bookingData: PassengerBookingData,
+      authority: string
+    ) =>
       bookPassengerRide(
         config['carpool-messages-api'] as string,
         auth as AuthState,
         originalTrip,
-        bookingData
+        bookingData,
+        authority
       ),
     getStreetRoute: getStreetRoute(config['journey-planner-api'] as string),
   };

--- a/src/shared/api/prepareBookingData.test.tsx
+++ b/src/shared/api/prepareBookingData.test.tsx
@@ -14,6 +14,7 @@ const baseTrip = (overrides: Partial<Extrajourney> = {}): Extrajourney =>
     id: 'ENT:ServiceJourney:1',
     estimatedVehicleJourney: {
       recordedAtTime: '2026-05-20T09:00:00.000Z',
+      lineRef: 'ENT:CarPooling:trip-1',
       publishedLineName: 'Carpooling trip',
       estimatedCalls: {
         estimatedCall: [
@@ -55,7 +56,9 @@ describe('prepareBookingData', () => {
     const trip = baseTrip();
     delete (trip as { id?: string }).id;
 
-    expect(() => prepareBookingData(trip, baseBooking())).toThrow(/must have an ID/);
+    expect(() => prepareBookingData(trip, baseBooking(), 'ENT:Authority:ENT')).toThrow(
+      /must have an ID/
+    );
   });
 
   it('throws when the original trip has fewer than 2 stops', () => {
@@ -63,17 +66,19 @@ describe('prepareBookingData', () => {
     trip.estimatedVehicleJourney.estimatedCalls.estimatedCall =
       trip.estimatedVehicleJourney.estimatedCalls.estimatedCall.slice(0, 1);
 
-    expect(() => prepareBookingData(trip, baseBooking())).toThrow(/at least 2 stops/);
+    expect(() => prepareBookingData(trip, baseBooking(), 'ENT:Authority:ENT')).toThrow(
+      /at least 2 stops/
+    );
   });
 
   it('preserves the original trip id', () => {
-    const result = prepareBookingData(baseTrip(), baseBooking());
+    const result = prepareBookingData(baseTrip(), baseBooking(), 'ENT:Authority:ENT');
 
     expect(result.input.id).toBe('ENT:ServiceJourney:1');
   });
 
   it('inserts pickup and dropoff between the original first and last stops and reorders them', () => {
-    const result = prepareBookingData(baseTrip(), baseBooking());
+    const result = prepareBookingData(baseTrip(), baseBooking(), 'ENT:Authority:ENT');
 
     const calls = result.input.estimatedVehicleJourney.estimatedCalls.estimatedCall;
     expect(calls).toHaveLength(4);
@@ -88,7 +93,7 @@ describe('prepareBookingData', () => {
   });
 
   it('formats pickup and dropoff stop names with lat,lng to 4 decimals', () => {
-    const result = prepareBookingData(baseTrip(), baseBooking());
+    const result = prepareBookingData(baseTrip(), baseBooking(), 'ENT:Authority:ENT');
 
     const calls = result.input.estimatedVehicleJourney.estimatedCalls.estimatedCall;
     expect(calls[1].stopPointName).toBe('Passenger Pickup (59.9139, 10.7522)');
@@ -97,7 +102,7 @@ describe('prepareBookingData', () => {
 
   it('places pickup at 1/3 and dropoff at 2/3 of the journey when times are not provided', () => {
     // Journey is 09:00 -> 15:00 = 6h. 1/3 = 11:00, 2/3 = 13:00.
-    const result = prepareBookingData(baseTrip(), baseBooking());
+    const result = prepareBookingData(baseTrip(), baseBooking(), 'ENT:Authority:ENT');
 
     const calls = result.input.estimatedVehicleJourney.estimatedCalls.estimatedCall;
     expect(calls[1].aimedDepartureTime).toBe('2026-06-01T11:00:00.000Z');
@@ -112,7 +117,8 @@ describe('prepareBookingData', () => {
       baseBooking({
         pickupTime: '2026-06-01T10:15:00.000Z',
         dropoffTime: '2026-06-01T14:45:00.000Z',
-      })
+      }),
+      'ENT:Authority:ENT'
     );
 
     const calls = result.input.estimatedVehicleJourney.estimatedCalls.estimatedCall;
@@ -121,7 +127,11 @@ describe('prepareBookingData', () => {
   });
 
   it('adds passengerDeviationBudget to derive latestExpectedArrivalTime', () => {
-    const result = prepareBookingData(baseTrip(), baseBooking({ passengerDeviationBudget: 15 }));
+    const result = prepareBookingData(
+      baseTrip(),
+      baseBooking({ passengerDeviationBudget: 15 }),
+      'ENT:Authority:ENT'
+    );
 
     const calls = result.input.estimatedVehicleJourney.estimatedCalls.estimatedCall;
     expect(calls[1].latestExpectedArrivalTime).toBe('2026-06-01T11:15:00.000Z');
@@ -131,7 +141,8 @@ describe('prepareBookingData', () => {
   it('omits latestExpectedArrivalTime when passengerDeviationBudget is not provided', () => {
     const result = prepareBookingData(
       baseTrip(),
-      baseBooking({ passengerDeviationBudget: undefined })
+      baseBooking({ passengerDeviationBudget: undefined }),
+      'ENT:Authority:ENT'
     );
 
     const calls = result.input.estimatedVehicleJourney.estimatedCalls.estimatedCall;
@@ -140,14 +151,18 @@ describe('prepareBookingData', () => {
   });
 
   it('increments the onboard count by the number of passengers at pickup', () => {
-    const result = prepareBookingData(baseTrip(), baseBooking({ numberOfPassengers: 3 }));
+    const result = prepareBookingData(
+      baseTrip(),
+      baseBooking({ numberOfPassengers: 3 }),
+      'ENT:Authority:ENT'
+    );
 
     const pickup = result.input.estimatedVehicleJourney.estimatedCalls.estimatedCall[1];
     expect(pickup.expectedDepartureOccupancy?.[0].onboardCount).toBe(4); // 1 (existing) + 3
   });
 
   it('inherits totalCapacity from the original first stop', () => {
-    const result = prepareBookingData(baseTrip(), baseBooking());
+    const result = prepareBookingData(baseTrip(), baseBooking(), 'ENT:Authority:ENT');
 
     const pickup = result.input.estimatedVehicleJourney.estimatedCalls.estimatedCall[1];
     const dropoff = result.input.estimatedVehicleJourney.estimatedCalls.estimatedCall[2];
@@ -156,7 +171,7 @@ describe('prepareBookingData', () => {
   });
 
   it('inherits destinationDisplay from the original last stop', () => {
-    const result = prepareBookingData(baseTrip(), baseBooking());
+    const result = prepareBookingData(baseTrip(), baseBooking(), 'ENT:Authority:ENT');
 
     const calls = result.input.estimatedVehicleJourney.estimatedCalls.estimatedCall;
     expect(calls[1].destinationDisplay).toBe('Bergen');

--- a/src/shared/api/prepareBookingData.tsx
+++ b/src/shared/api/prepareBookingData.tsx
@@ -15,7 +15,8 @@ export interface PassengerBookingData {
 
 export function prepareBookingData(
   originalTrip: Extrajourney,
-  bookingData: PassengerBookingData
+  bookingData: PassengerBookingData,
+  authority: string
 ): {
   codespace: string;
   authority: string;
@@ -23,6 +24,13 @@ export function prepareBookingData(
 } {
   if (!originalTrip.id) {
     throw new Error('Original trip must have an ID');
+  }
+
+  // Codespace is the prefix of the trip's lineRef (`<CODESPACE>:CarPooling:<uuid>`).
+  // It must match the supplied authority — nunamnir enforces this server-side.
+  const codespace = originalTrip.estimatedVehicleJourney.lineRef?.split(':')[0];
+  if (!codespace) {
+    throw new Error('Original trip is missing a lineRef; cannot determine codespace');
   }
 
   const originalCalls = originalTrip.estimatedVehicleJourney.estimatedCalls.estimatedCall;
@@ -49,7 +57,7 @@ export function prepareBookingData(
   // Create pickup stop (point location, not flexible area)
   const pickupStop: EstimatedCall = {
     order: 2, // Between first (1) and last stop
-    stopPointRef: `ENT:PickupPoint:${uuidv4()}`,
+    stopPointRef: `${codespace}:PickupPoint:${uuidv4()}`,
     stopPointName: `Passenger Pickup (${bookingData.pickupCoordinates[1].toFixed(4)}, ${bookingData.pickupCoordinates[0].toFixed(4)})`,
     destinationDisplay: lastCall.destinationDisplay,
     aimedDepartureTime: bookingData.pickupTime || pickupTime.toISOString(),
@@ -84,7 +92,7 @@ export function prepareBookingData(
   // Create dropoff stop (point location, not flexible area)
   const dropoffStop: EstimatedCall = {
     order: 3, // After pickup but before final destination
-    stopPointRef: `ENT:DropoffPoint:${uuidv4()}`,
+    stopPointRef: `${codespace}:DropoffPoint:${uuidv4()}`,
     stopPointName: `Passenger Dropoff (${bookingData.dropoffCoordinates[1].toFixed(4)}, ${bookingData.dropoffCoordinates[0].toFixed(4)})`,
     destinationDisplay: lastCall.destinationDisplay,
     aimedArrivalTime: bookingData.dropoffTime || dropoffTime.toISOString(),
@@ -142,8 +150,8 @@ export function prepareBookingData(
   };
 
   return {
-    codespace: 'ENT', // Using the same codespace as original trip creation
-    authority: 'ENT:Authority:ENT', // Using the same authority as original trip creation
+    codespace,
+    authority,
     input: updatedTrip,
   };
 }

--- a/src/shared/api/prepareCarpoolingFormData.test.tsx
+++ b/src/shared/api/prepareCarpoolingFormData.test.tsx
@@ -10,7 +10,6 @@ vi.mock('uuid', () => ({
 const baseForm = (
   overrides: Partial<CarPoolingTripDataFormData> = {}
 ): CarPoolingTripDataFormData => ({
-  codespace: 'ENT',
   authority: 'ENT:Authority:ENT',
   operator: 'ENT:Operator:1',
   departureStopName: 'Oslo S',

--- a/src/shared/api/prepareCarpoolingFormData.tsx
+++ b/src/shared/api/prepareCarpoolingFormData.tsx
@@ -15,18 +15,22 @@ function prepareCarpoolingFormData(formData: CarPoolingTripDataFormData): {
     // an unrelated null deref further down.
     throw new Error('Cannot prepare carpooling form: departure and destination stops are required');
   }
+  // Codespace is the NeTEx authority id prefix: `<CODESPACE>:Authority:<X>`.
+  // The form only carries the authority — derive the codespace from it so the
+  // two cannot drift apart (nunamnir now rejects mismatched pairs).
+  const codespace = formData.authority.split(':')[0];
   const intermediateCalls = formData.intermediateCalls.map((call, index) => ({
     ...call,
     order: index + 2,
   }));
   const destinationOrder = intermediateCalls.length + 2;
   const variables = {
-    codespace: formData.codespace,
+    codespace,
     authority: formData.authority,
     input: {
       estimatedVehicleJourney: {
         recordedAtTime: dayjs().toISOString(),
-        lineRef: formData.lineRef ?? `${formData.codespace}:CarPooling:${uuidv4()}`,
+        lineRef: formData.lineRef ?? `${codespace}:CarPooling:${uuidv4()}`,
         directionRef: '0',
         estimatedVehicleJourneyCode: formData.estimatedVehicleJourneyCode ?? '',
         extraJourney: true,
@@ -37,7 +41,7 @@ function prepareCarpoolingFormData(formData: CarPoolingTripDataFormData): {
         externalLineRef: '', // TODO: Reference back to original line which usually a evj is an replacement for... Check to see if mandatory in schema
         operatorRef: formData.operator,
         monitored: true,
-        dataSource: 'ENT', // TODO: Remove hard coding
+        dataSource: codespace,
         cancellation: formData.tripCancellation,
         isCompleteStopSequence: true,
         estimatedCalls: {

--- a/src/shared/data/schema.graphqls
+++ b/src/shared/data/schema.graphqls
@@ -49,9 +49,8 @@ type Codespace {
 }
 
 enum Permission {
-  MESSAGES
-  CANCELLATIONS
-  EXTRAJOURNEYS
+  VIEW_CARPOOLING_DATA
+  ADMIN_CARPOOLING_DATA
 }
 
 type Mutation {

--- a/src/shared/error-message/humanizeCode.tsx
+++ b/src/shared/error-message/humanizeCode.tsx
@@ -1,2 +1,12 @@
+// Human-readable labels for error codes that the default title-casing
+// wouldn't convey clearly. Server-side codes come from GraphQL extensions —
+// `FORBIDDEN` is Spring Security's mapping for @PreAuthorize denials.
+const FRIENDLY_LABELS: Record<string, string> = {
+  FORBIDDEN: 'Permission denied',
+  UNAUTHORIZED: 'Not signed in',
+  ACCESS_DENIED: 'Permission denied',
+};
+
 export const humanizeCode = (code: string) =>
+  FRIENDLY_LABELS[code] ??
   code.charAt(0).toUpperCase() + code.slice(1).toLowerCase().replace(/_/g, ' ');

--- a/src/shared/hooks/useAuthorities.tsx
+++ b/src/shared/hooks/useAuthorities.tsx
@@ -9,21 +9,16 @@ type CodespaceAuthority = {
   name: string;
 };
 
-const Permission = {
-  MESSAGES: 'MESSAGES',
-  CANCELLATIONS: 'CANCELLATIONS',
-  EXTRAJOURNEYS: 'EXTRAJOURNEYS',
-} as const;
-
-type Permission = keyof typeof Permission;
+type Permission = 'VIEW_CARPOOLING_DATA' | 'ADMIN_CARPOOLING_DATA';
 
 type Codespace = {
   id: string;
-  permissions: [Permission];
+  permissions: Permission[];
 };
 
 export const useAuthorities: () => {
   authorities: CodespaceAuthority[];
+  adminAuthorities: CodespaceAuthority[];
   allowedCodespaces: Codespace[];
 } = () => {
   const auth = useAuth();
@@ -76,5 +71,15 @@ export const useAuthorities: () => {
     fetchAuthorities().then();
   }, [auth, config, triggerNoAccess]);
 
-  return { authorities: codespaceAuthorities, allowedCodespaces };
+  // Codespaces with write permission. Use this for surfaces that lead to a
+  // mutation (creating a trip, booking a ride) so the user doesn't see options
+  // that would only fail on submit with a 403 from the server.
+  const adminCodespaceIds = new Set(
+    allowedCodespaces.filter(c => c.permissions.includes('ADMIN_CARPOOLING_DATA')).map(c => c.id)
+  );
+  const adminAuthorities = codespaceAuthorities.filter(a =>
+    adminCodespaceIds.has(a.id.split(':')[0])
+  );
+
+  return { authorities: codespaceAuthorities, adminAuthorities, allowedCodespaces };
 };


### PR DESCRIPTION
Frontend changes for true multi-tenancy plus the new view/admin carpooling role model nunamnir and subula now enforce.

Carpooling form / write path:
- Drop the codespace form field; derive it everywhere from the picked authority's prefix. dataSource and lineRef on the SIRI payload follow suit (no more dataSource: 'ENT').
- Default the authority dropdown to an ENT-prefixed value when available and hide the dropdown entirely when the user has only one authority.
- Stop reconstructing 'ENT'/'ENT:Authority:ENT' in mapToFormData, prepareBookingData, and useBookPassengerRide. Thread the trip's authority through as a parameter; derive its codespace from the trip's lineRef.

Routing and read path:
- Routes carry codespace: /plan-trip/:codespace/:id and /book-trip/:codespace/:tripId. The booking URL the form pre-fills now includes the codespace so passengers land on the correct tenant.
- CarPoolingTrips fans out across every allowed codespace and merges the results, so non-ENT users see their own trips.
- CarPoolingTripData and PassengerTripBooking read codespace from the URL and look up the matching authority via useAuthorities.

Permissions:
- Permission enum follows nunamnir: VIEW_CARPOOLING_DATA and ADMIN_CARPOOLING_DATA (replacing MESSAGES/CANCELLATIONS/EXTRAJOURNEYS).
- Codespace.permissions type fixed from a length-1 tuple to a list.