### PR TITLE
Permission-aware UI: hide unavailable trip actions, add permissions t…

### DIFF
--- a/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
@@ -70,6 +70,10 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
   // Without this filter, a view-only user would see authorities they can't
   // submit to and only learn of the rejection on a 403 from the server.
   const { adminAuthorities: authorities } = useAuthorities();
+  // A view-only user opening the new-trip page has no codespace they can
+  // submit to. Surface that up front rather than letting them fill out the
+  // form only to fail Yup's authority-required validation on submit.
+  const noAdminAccess = !tripData && authorities.length === 0;
   const operators = useOperators();
 
   // New trips get a client-generated id so the booking URL (this app's
@@ -735,8 +739,14 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
         }}
       />
 
+      {noAdminAccess && (
+        <Alert severity="info">
+          You don&apos;t have permission to create trips in any of your codespaces.
+        </Alert>
+      )}
+
       <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-        <Button type="submit" variant="contained" color="primary">
+        <Button type="submit" variant="contained" color="primary" disabled={noAdminAccess}>
           Submit trip
         </Button>
         <Button

--- a/src/features/planned-trips/CarPoolingTrips.tsx
+++ b/src/features/planned-trips/CarPoolingTrips.tsx
@@ -33,7 +33,10 @@ export default function CarPoolingTrips() {
   const [failedCodespaces, setFailedCodespaces] = useState<string[]>([]);
 
   const queryExtraJourneys = useQueryExtraJourney();
-  const { authorities } = useAuthorities();
+  const { authorities, allowedCodespaces } = useAuthorities();
+  const adminCodespaceIds = new Set(
+    allowedCodespaces.filter(c => c.permissions.includes('ADMIN_CARPOOLING_DATA')).map(c => c.id)
+  );
 
   useEffect(() => {
     const message = (location.state as { savedMessage?: string } | null)?.savedMessage;
@@ -113,23 +116,31 @@ export default function CarPoolingTrips() {
         // It identifies which Firestore partition the trip lives in, so it must
         // be in the URL for the edit/book pages to know which tenant to query.
         const codespace = params.row.estimatedVehicleJourney.lineRef?.split(':')[0] ?? '';
+        // Edit and Book both go through write mutations on nunamnir, so only
+        // show them when the user actually has admin on that codespace —
+        // otherwise the buttons just lead to a 403.
+        const canModify = adminCodespaceIds.has(codespace);
         return (
           <Box>
-            <Button
-              variant="contained"
-              size="small"
-              onClick={() => navigate(`/plan-trip/${codespace}/${params.row.id}`)}
-            >
-              Edit
-            </Button>
-            <Button
-              variant="outlined"
-              size="small"
-              onClick={() => navigate(`/book-trip/${codespace}/${params.row.id}`)}
-              style={{ marginLeft: 8 }}
-            >
-              Book Ride
-            </Button>
+            {canModify && (
+              <Button
+                variant="contained"
+                size="small"
+                onClick={() => navigate(`/plan-trip/${codespace}/${params.row.id}`)}
+              >
+                Edit
+              </Button>
+            )}
+            {canModify && (
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={() => navigate(`/book-trip/${codespace}/${params.row.id}`)}
+                style={{ marginLeft: 8 }}
+              >
+                Book Ride
+              </Button>
+            )}
           </Box>
         );
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -12,6 +12,11 @@
   "user.name": "Username",
   "user.userAccount": "User account",
   "user.logout": "Log out",
+  "user.permissions.title": "Permissions",
+  "user.permissions.empty": "No codespace access.",
+  "user.permissions.codespace": "Codespace",
+  "user.permissions.read": "Read",
+  "user.permissions.admin": "Admin",
 
   "data": "Data overview",
   "data.title": "Data Overview",

--- a/src/shared/components/dialogs/UserDialog.tsx
+++ b/src/shared/components/dialogs/UserDialog.tsx
@@ -3,7 +3,19 @@ import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
 import { useTranslation } from 'react-i18next';
+import { useAuthorities } from '../../hooks/useAuthorities.tsx';
 
 interface UserDialogProps {
   open: boolean;
@@ -13,11 +25,58 @@ interface UserDialogProps {
 
 export default function UserDialog({ open, onClose, onLogout }: UserDialogProps) {
   const { t } = useTranslation();
+  const { allowedCodespaces } = useAuthorities();
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>{t('user.userAccount')}</DialogTitle>
-      <DialogContent dividers></DialogContent>
+      <DialogContent dividers>
+        <Typography variant="subtitle1" gutterBottom>
+          {t('user.permissions.title', 'Permissions')}
+        </Typography>
+        {allowedCodespaces.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            {t('user.permissions.empty', 'No codespace access.')}
+          </Typography>
+        ) : (
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>{t('user.permissions.codespace', 'Codespace')}</TableCell>
+                  <TableCell align="center">{t('user.permissions.read', 'Read')}</TableCell>
+                  <TableCell align="center">{t('user.permissions.admin', 'Admin')}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {allowedCodespaces.map(codespace => {
+                  const hasRead = codespace.permissions.includes('VIEW_CARPOOLING_DATA');
+                  const hasAdmin = codespace.permissions.includes('ADMIN_CARPOOLING_DATA');
+                  return (
+                    <TableRow key={codespace.id}>
+                      <TableCell>{codespace.id}</TableCell>
+                      <TableCell align="center">
+                        {hasRead ? (
+                          <CheckIcon fontSize="small" color="success" aria-label="yes" />
+                        ) : (
+                          <CloseIcon fontSize="small" color="disabled" aria-label="no" />
+                        )}
+                      </TableCell>
+                      <TableCell align="center">
+                        {hasAdmin ? (
+                          <CheckIcon fontSize="small" color="success" aria-label="yes" />
+                        ) : (
+                          <CloseIcon fontSize="small" color="disabled" aria-label="no" />
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DialogContent>
       <DialogActions>
         <Button onClick={onLogout} variant="contained">
           {t('user.logout')}


### PR DESCRIPTION
…able

Follow-up UX on top of the multi-tenant carpooling refactor:

- Hide Edit and Book Ride in the trips grid for rows whose codespace the user only has view access on. Previously these buttons led the user to the edit/book page only to fail with a 403 on submit.
- Show an inline alert and disable Submit on the new-trip form when the user has no admin codespace anywhere, instead of letting them fill out the form and trip Yup's authority-required validation on save.
- Add a Permissions table to the user-icon dialog showing Read / Admin state per codespace, sourced from useAuthorities().allowedCodespaces.