### PR TITLE
Memoize adminAuthorities to break infinite render loop

### DIFF
--- a/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
@@ -531,6 +531,10 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
           }}
         />
         <FormHelperText>{errors.operator?.message}</FormHelperText>
+        <Alert severity="warning" sx={{ mt: 1 }}>
+          The operator value currently has no effect downstream. Only Entur is accepted until a
+          consumer starts using this field.
+        </Alert>
       </FormControl>
       <Typography variant="h6" component="h2">
         Departure

--- a/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
@@ -88,6 +88,7 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     handleSubmit,
     control,
     setValue,
+    getValues,
     watch,
     formState: { errors },
     reset,
@@ -142,9 +143,13 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     // Fill in the default booking URL once the authority (and therefore the
     // codespace) is known. Skip if the user has already entered something — we
     // never want to clobber a manual edit or an edited trip's existing URL.
+    // Read id off the form so that, when editing a trip that has no saved URL,
+    // we generate one pointing at the actual trip's id rather than the
+    // client-generated `newTripId` (which is only correct for new trips).
     if (authority && !contactUrl) {
       const codespace = authority.split(':')[0];
-      setValue('contactUrl', `${window.location.origin}/book-trip/${codespace}/${newTripId}`);
+      const tripId = getValues('id') ?? newTripId;
+      setValue('contactUrl', `${window.location.origin}/book-trip/${codespace}/${tripId}`);
     }
 
     if (operators.length && !operator) {
@@ -203,6 +208,7 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     mapDepartureFlexibleStop,
     mapDestinationFlexibleStop,
     setValue,
+    getValues,
     drawingStopsAllowed,
     error,
     errors?.departureFlexibleStop?.message,
@@ -233,16 +239,13 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     )
       .then(result => {
         if (cancelled || !result) return;
-        if (result.expectedEndTime) {
+        // Only auto-fill arrival time when it's not already set — otherwise
+        // editing a trip would silently overwrite the saved arrival with OTP's
+        // freshly-computed ETA on every street-route fire.
+        if (result.expectedEndTime && !getValues('destinationDatetime')) {
           setValue('destinationDatetime', dayjs(result.expectedEndTime), {
             shouldValidate: true,
           });
-        }
-        if (result.fromName) {
-          setValue('departureStopName', result.fromName, { shouldValidate: true });
-        }
-        if (result.toName) {
-          setValue('destinationStopName', result.toName, { shouldValidate: true });
         }
       })
       .catch(() => {
@@ -259,6 +262,7 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     departureMs,
     streetRoute,
     setValue,
+    getValues,
   ]);
 
   // Helper function to determine stop type and get appropriate icon/color

--- a/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
@@ -578,16 +578,16 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
           );
         }}
       />
-      <Button
-        variant="contained"
-        disabled={!!departureFlexibleStop || !drawingStopsAllowed}
-        onClick={() => onAddDeparturestopClick()}
-      >
-        Add stop
-      </Button>
-      <Box display="flex" gap={1}>
+      <Box display="flex" gap={1} flexWrap="wrap">
         <Button
           variant="contained"
+          disabled={!!departureFlexibleStop || !drawingStopsAllowed}
+          onClick={() => onAddDeparturestopClick()}
+        >
+          Add stop
+        </Button>
+        <Button
+          variant="outlined"
           onClick={onRemoveDepartureStopClick}
           disabled={!departureFlexibleStop}
         >
@@ -596,7 +596,7 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
         {mapDepartureFlexibleStop?.id && (
           <IconButton
             disabled={!departureFlexibleStop}
-            aria-label="Zoom to destination stop"
+            aria-label="Zoom to departure stop"
             onClick={() => onZoomToFeature(mapDepartureFlexibleStop.id as string)}
           >
             <GpsFixedIcon />
@@ -646,16 +646,16 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
           );
         }}
       />
-      <Button
-        variant="contained"
-        disabled={!!destinationFlexibleStop || !drawingStopsAllowed}
-        onClick={() => onAddDestinationtopClick()}
-      >
-        Add stop
-      </Button>
-      <Box display="flex" gap={1}>
+      <Box display="flex" gap={1} flexWrap="wrap">
         <Button
           variant="contained"
+          disabled={!!destinationFlexibleStop || !drawingStopsAllowed}
+          onClick={() => onAddDestinationtopClick()}
+        >
+          Add stop
+        </Button>
+        <Button
+          variant="outlined"
           onClick={onRemoveDestinationStopClick}
           disabled={!destinationFlexibleStop}
         >
@@ -673,6 +673,9 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
       </Box>
 
       <Divider />
+      <Typography variant="h6" component="h2">
+        Trip details
+      </Typography>
 
       <Controller
         name="driverDeviationBudget"
@@ -709,39 +712,41 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
         }}
       />
 
-      <Controller
-        name="totalCapacity"
-        control={control}
-        render={({ field }) => {
-          return (
-            <TextField
-              {...field}
-              value={field.value ?? ''}
-              label="Total Capacity"
-              error={!!errors.totalCapacity}
-              helperText={errors.totalCapacity?.message}
-              fullWidth
-            />
-          );
-        }}
-      />
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+        <Controller
+          name="totalCapacity"
+          control={control}
+          render={({ field }) => {
+            return (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Total capacity"
+                error={!!errors.totalCapacity}
+                helperText={errors.totalCapacity?.message}
+                sx={{ flex: 1, minWidth: 160 }}
+              />
+            );
+          }}
+        />
 
-      <Controller
-        name="onboardCount"
-        control={control}
-        render={({ field }) => {
-          return (
-            <TextField
-              {...field}
-              value={field.value ?? ''}
-              label="Number of people in the vehicle"
-              error={!!errors.onboardCount}
-              helperText={errors.onboardCount?.message}
-              fullWidth
-            />
-          );
-        }}
-      />
+        <Controller
+          name="onboardCount"
+          control={control}
+          render={({ field }) => {
+            return (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Number of people in the vehicle"
+                error={!!errors.onboardCount}
+                helperText={errors.onboardCount?.message}
+                sx={{ flex: 1, minWidth: 160 }}
+              />
+            );
+          }}
+        />
+      </Box>
 
       {noAdminAccess && (
         <Alert severity="info">

--- a/src/features/plan-trip/model/carPoolingTripDataSchema.test.tsx
+++ b/src/features/plan-trip/model/carPoolingTripDataSchema.test.tsx
@@ -40,6 +40,15 @@ describe('carPoolingTripDataSchema', () => {
     await expect(carPoolingTripDataSchema.validate(input)).rejects.toThrow();
   });
 
+  it.each(['ATB:Operator:1', 'RUT:Operator:99', 'foo'])(
+    'rejects non-Entur operator %s',
+    async value => {
+      await expect(
+        carPoolingTripDataSchema.validate({ ...validInput(), operator: value })
+      ).rejects.toThrow(/Only Entur is accepted/);
+    }
+  );
+
   it('requires departureFlexibleStop with a helpful message', async () => {
     await expect(
       carPoolingTripDataSchema.validate({ ...validInput(), departureFlexibleStop: undefined })

--- a/src/features/plan-trip/model/carPoolingTripDataSchema.tsx
+++ b/src/features/plan-trip/model/carPoolingTripDataSchema.tsx
@@ -32,7 +32,14 @@ const dateSchema = Yup.mixed<Dayjs>().dayjs('Not a valid date');
 
 export const carPoolingTripDataSchema = Yup.object({
   authority: Yup.string().required(),
-  operator: Yup.string().required(),
+  operator: Yup.string()
+    .required()
+    // The operator field is currently dead data downstream (see ROR pipeline:
+    // tadmustum -> nunamnir -> subula -> nusku, and OTP's CarpoolTrip.provider
+    // — no consumer reads it). Until something actually depends on the value,
+    // restrict to Entur to avoid producing data that might be wrong but never
+    // noticed.
+    .matches(/^ENT:/, 'Only Entur is accepted as operator for now'),
   departureStopName: Yup.string()
     .min(3, 'Departure stop name must be at least 3 characters')
     .required(),

--- a/src/features/planned-trips/CarPoolingTrips.tsx
+++ b/src/features/planned-trips/CarPoolingTrips.tsx
@@ -37,6 +37,13 @@ export default function CarPoolingTrips() {
   const adminCodespaceIds = new Set(
     allowedCodespaces.filter(c => c.permissions.includes('ADMIN_CARPOOLING_DATA')).map(c => c.id)
   );
+  // Trips don't carry the authority name; resolve it from the codespace prefix
+  // of lineRef against the authorities the user has access to. Trips can only
+  // appear in the list if their codespace was queried, so a hit is guaranteed.
+  const authorityNameByCodespace = useMemo(
+    () => new Map(authorities.map(a => [a.id.split(':')[0], a.name])),
+    [authorities]
+  );
 
   useEffect(() => {
     const message = (location.state as { savedMessage?: string } | null)?.savedMessage;
@@ -150,6 +157,16 @@ export default function CarPoolingTrips() {
       headerName: 'ID',
       minWidth: 220,
       flex: 1,
+    },
+    {
+      field: 'authority',
+      headerName: 'Authority',
+      minWidth: 140,
+      flex: 1,
+      valueGetter: (_value: string, row: Extrajourney) => {
+        const codespace = row.estimatedVehicleJourney.lineRef?.split(':')[0] ?? '';
+        return authorityNameByCodespace.get(codespace) ?? codespace;
+      },
     },
     {
       field: 'cancellation',
@@ -302,6 +319,7 @@ export default function CarPoolingTrips() {
         columns={columns}
         columnVisibilityModel={{
           id: showHiddenFields,
+          authority: showHiddenFields,
           latestExpectedArrivalTime: showHiddenFields,
           expiresAtEpochMs: showHiddenFields,
         }}

--- a/src/shared/api/journeyPlannerStreetRoute.tsx
+++ b/src/shared/api/journeyPlannerStreetRoute.tsx
@@ -6,17 +6,6 @@ export interface StreetRouteResult {
   expectedEndTime: string;
   duration: number;
   distance: number;
-  fromName: string | null;
-  toName: string | null;
-}
-
-interface LegPlace {
-  name?: string | null;
-}
-
-interface Leg {
-  fromPlace?: LegPlace | null;
-  toPlace?: LegPlace | null;
 }
 
 interface TripPattern {
@@ -24,7 +13,6 @@ interface TripPattern {
   expectedEndTime: string;
   duration: number;
   distance: number;
-  legs?: Leg[] | null;
 }
 
 const getStreetRoute =
@@ -46,14 +34,6 @@ const getStreetRoute =
             expectedEndTime
             duration
             distance
-            legs {
-              fromPlace {
-                name
-              }
-              toPlace {
-                name
-              }
-            }
           }
         }
       }
@@ -71,17 +51,11 @@ const getStreetRoute =
     if (!patterns || patterns.length === 0) return null;
 
     const pattern = patterns[0];
-    const legs = pattern.legs ?? [];
-    const fromName = legs[0]?.fromPlace?.name ?? null;
-    const toName = legs[legs.length - 1]?.toPlace?.name ?? null;
-
     return {
       expectedStartTime: pattern.expectedStartTime,
       expectedEndTime: pattern.expectedEndTime,
       duration: pattern.duration,
       distance: pattern.distance,
-      fromName,
-      toName,
     };
   };
 

--- a/src/shared/hooks/useAuthorities.tsx
+++ b/src/shared/hooks/useAuthorities.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useConfig } from '../../contexts/ConfigContext.tsx';
 import { useAuth } from 'react-oidc-context';
 import api from '../api/api.tsx';
@@ -74,12 +74,14 @@ export const useAuthorities: () => {
   // Codespaces with write permission. Use this for surfaces that lead to a
   // mutation (creating a trip, booking a ride) so the user doesn't see options
   // that would only fail on submit with a 403 from the server.
-  const adminCodespaceIds = new Set(
-    allowedCodespaces.filter(c => c.permissions.includes('ADMIN_CARPOOLING_DATA')).map(c => c.id)
-  );
-  const adminAuthorities = codespaceAuthorities.filter(a =>
-    adminCodespaceIds.has(a.id.split(':')[0])
-  );
+  // Memoized: otherwise a fresh array on every render causes effects that list
+  // adminAuthorities in their deps to refire each render and loop with setValue.
+  const adminAuthorities = useMemo(() => {
+    const adminCodespaceIds = new Set(
+      allowedCodespaces.filter(c => c.permissions.includes('ADMIN_CARPOOLING_DATA')).map(c => c.id)
+    );
+    return codespaceAuthorities.filter(a => adminCodespaceIds.has(a.id.split(':')[0]));
+  }, [allowedCodespaces, codespaceAuthorities]);
 
   return { authorities: codespaceAuthorities, adminAuthorities, allowedCodespaces };
 };


### PR DESCRIPTION
Why: adminAuthorities was a fresh array on every render of useAuthorities, so any component listing it in a useEffect dep array (CarPoolingTripDataForm) re-ran the effect every render. That effect calls setValue, which notifies RHF watchers and triggers another render, hitting React's Maximum update depth limit and preventing mouse clicks from reaching the AppBar links on the edit-trip page.