### PR TITLE
Draw the routed driving path on the trip maps

### DIFF
--- a/src/features/passenger-booking/PassengerTripBooking.test.tsx
+++ b/src/features/passenger-booking/PassengerTripBooking.test.tsx
@@ -166,6 +166,18 @@ describe('PassengerTripBooking', () => {
     expect(await screen.findByText('Oslo S → Bergen stasjon')).toBeInTheDocument();
   });
 
+  it('warns when the driving route cannot be fetched from the journey planner', async () => {
+    // The stubbed street router returns null, so routing the trip's own path
+    // fails and the page falls back to straight lines — with a warning.
+    queryExtraJourney.mockResolvedValue({ data: { extraJourney: trip } });
+
+    renderAt();
+
+    expect(
+      await screen.findByText(/Could not fetch the driving route from the journey planner/i)
+    ).toBeInTheDocument();
+  });
+
   it('disables Book Ride until both pickup and dropoff are selected', async () => {
     const user = userEvent.setup();
     queryExtraJourney.mockResolvedValue({ data: { extraJourney: trip } });

--- a/src/features/passenger-booking/PassengerTripBooking.tsx
+++ b/src/features/passenger-booking/PassengerTripBooking.tsx
@@ -24,7 +24,10 @@ import {
   type SvgIconComponent,
 } from '@mui/icons-material';
 import type { Extrajourney } from '../../shared/model/Extrajourney';
+import type { Position } from 'geojson';
 import StopOccupancy from '../../shared/components/StopOccupancy';
+import { routeLegChain, type RouteLegGeometries } from '../../shared/api/routeLegChain';
+import loadFeatureFromFlexArea from '../plan-trip/util/loadFeatureFromFlexArea';
 import {
   routedBookingPreview,
   type BookingRoutePreview,
@@ -122,6 +125,44 @@ export default function PassengerTripBooking() {
   // visible meanwhile so the times update once instead of flickering.
   const [routedPreview, setRoutedPreview] = useState<BookingRoutePreview | null>(null);
   const [routePending, setRoutePending] = useState(false);
+
+  // The driving route of the trip as planned (origin -> intermediate stops ->
+  // destination), shown on the map before a booking preview exists — i.e.
+  // before the passenger has selected both pickup and dropoff. Null while
+  // routing (nothing drawn), 'failed' when it can't be routed (the map shows
+  // its straight-line fallback).
+  const [tripLegGeometries, setTripLegGeometries] = useState<RouteLegGeometries>(null);
+
+  useEffect(() => {
+    if (!trip) {
+      setTripLegGeometries(null);
+      return;
+    }
+    const calls = trip.estimatedVehicleJourney.estimatedCalls?.estimatedCall ?? [];
+    const coords = calls.map(
+      call =>
+        loadFeatureFromFlexArea(call.departureStopAssignment?.expectedFlexibleArea)?.geometry
+          .coordinates ?? null
+    );
+    const departure = calls[0]?.aimedDepartureTime || calls[0]?.expectedDepartureTime;
+    // A stop without a resolvable coordinate can't be routed (or drawn as a
+    // partial route) — show the straight-line fallback.
+    if (coords.length < 2 || coords.some(coord => coord == null) || !departure) {
+      setTripLegGeometries('failed');
+      return;
+    }
+    let cancelled = false;
+    routeLegChain(coords as Position[], departure, getStreetRoute)
+      .then(chain => {
+        if (!cancelled) setTripLegGeometries(chain ? chain.legGeometries : 'failed');
+      })
+      .catch(() => {
+        if (!cancelled) setTripLegGeometries('failed');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [trip, getStreetRoute]);
 
   // Parse coordinates from URL parameters
   const parseCoordinatesFromURL = (param: string | null): [number, number] | undefined => {
@@ -389,6 +430,13 @@ export default function PassengerTripBooking() {
   ]);
 
   const activePreview = routedPreview;
+
+  // What the map should draw: the preview's routed path when a preview
+  // exists ('failed' when it couldn't be routed), otherwise the trip's own
+  // routed path. 'failed' also drives the routing warning below.
+  const displayedLegGeometries: RouteLegGeometries = activePreview
+    ? (activePreview.legGeometries ?? 'failed')
+    : tripLegGeometries;
 
   if (loading) {
     return (
@@ -754,9 +802,16 @@ export default function PassengerTripBooking() {
                 View the trip route and click the buttons below to select your pickup and drop-off
                 locations on the map.
               </Typography>
+              {displayedLegGeometries === 'failed' && (
+                <Alert severity="warning" sx={{ mb: 2 }}>
+                  Could not fetch the driving route from the journey planner. The map shows straight
+                  lines between the stops instead, and stop times may be rough estimates.
+                </Alert>
+              )}
               <PassengerBookingMap
                 trip={trip}
                 routeCalls={estimatedCalls}
+                legGeometries={displayedLegGeometries}
                 onPickupLocationSelect={handlePickupLocationSelect}
                 onDropoffLocationSelect={handleDropoffLocationSelect}
                 pickupLocation={bookingData.pickupCoordinates}

--- a/src/features/passenger-booking/components/PassengerBookingMap.tsx
+++ b/src/features/passenger-booking/components/PassengerBookingMap.tsx
@@ -5,8 +5,6 @@ import {
   type MapRef,
   NavigationControl,
   Marker,
-  Source,
-  Layer,
 } from 'react-map-gl/maplibre';
 import { Box } from '@mui/material';
 import { LocationOn, FmdGood, DirectionsWalk } from '@mui/icons-material';
@@ -14,6 +12,8 @@ import { mapStyle } from '../../../shared/util/mapStyle.ts';
 import type { Extrajourney } from '../../../shared/model/Extrajourney';
 import type { EstimatedCall } from '../../../shared/model/EstimatedCall';
 import type { Feature, LineString, Point } from 'geojson';
+import type { RouteLegGeometries } from '../../../shared/api/routeLegChain.tsx';
+import RouteLineLayers from '../../../shared/components/RouteLineLayers.tsx';
 import loadFeatureFromFlexArea from '../../plan-trip/util/loadFeatureFromFlexArea.tsx';
 
 interface PassengerBookingMapProps {
@@ -21,6 +21,10 @@ interface PassengerBookingMapProps {
   // The authoritative ordered calls (from the booking preview) the route line
   // should follow. Falls back to the trip's own calls when not provided.
   routeCalls?: EstimatedCall[];
+  // Routed street geometry per leg of the route, drawn as a solid line.
+  // 'failed' draws the straight dashed line between the stops as a fallback;
+  // null draws nothing (route still being computed).
+  legGeometries?: RouteLegGeometries;
   onPickupLocationSelect?: (coordinates: [number, number], address?: string) => void;
   onDropoffLocationSelect?: (coordinates: [number, number], address?: string) => void;
   pickupLocation?: [number, number];
@@ -30,6 +34,7 @@ interface PassengerBookingMapProps {
 export default function PassengerBookingMap({
   trip,
   routeCalls,
+  legGeometries,
   onPickupLocationSelect,
   onDropoffLocationSelect,
   pickupLocation,
@@ -148,7 +153,7 @@ export default function PassengerBookingMap({
   }, [isMapReady, trip, getFlexibleAreas, pickupLocation, dropoffLocation]);
 
   const flexibleAreas = getFlexibleAreas();
-  const routeLine = createRouteLineString();
+  const fallbackRouteLine = createRouteLineString();
 
   return (
     <Box sx={{ height: '400px', width: '100%', position: 'relative' }}>
@@ -170,19 +175,7 @@ export default function PassengerBookingMap({
         <GeolocateControl position="top-right" />
 
         {/* Route Line */}
-        {routeLine && (
-          <Source type="geojson" data={routeLine}>
-            <Layer
-              id="route-line"
-              type="line"
-              paint={{
-                'line-color': '#FF9800',
-                'line-width': 4,
-                'line-dasharray': [2, 2],
-              }}
-            />
-          </Source>
-        )}
+        <RouteLineLayers legGeometries={legGeometries} fallbackLine={fallbackRouteLine} />
 
         {/* Stop Markers */}
         {flexibleAreas.map((area, index) => {

--- a/src/features/plan-trip/CarPoolingTrip.tsx
+++ b/src/features/plan-trip/CarPoolingTrip.tsx
@@ -9,6 +9,7 @@ import { type EditableMapHandle } from '../../shared/components/EditableMap.tsx'
 import EditableMap from '../../shared/components/EditableMap.tsx';
 import { useParams } from 'react-router-dom';
 import type { Feature } from 'geojson';
+import type { RouteLegGeometries } from '../../shared/api/routeLegChain.tsx';
 
 export default function CarPoolingTrip() {
   const { codespace, id } = useParams();
@@ -28,6 +29,10 @@ function CarPoolingTripView({ id, codespace }: { id?: string; codespace?: string
   const [collapsed, setCollapsed] = useState<boolean>(false);
   const [departureStopId, setDepartureStopId] = useState<string | null>(null);
   const [arrivalStopId, setArrivalStopId] = useState<string | null>(null);
+  // The routed driving path of the trip (one linestring per leg, through any
+  // intermediate stops), reported by the form whenever it (re)routes the
+  // trip; drawn on the map instead of the straight line.
+  const [routeGeometry, setRouteGeometry] = useState<RouteLegGeometries>(null);
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
@@ -76,6 +81,7 @@ function CarPoolingTripView({ id, codespace }: { id?: string; codespace?: string
           }}
           onDepartureStopChange={setDepartureStopId}
           onArrivalStopChange={setArrivalStopId}
+          onRouteGeometryChange={setRouteGeometry}
         />
       </Box>
 
@@ -107,6 +113,7 @@ function CarPoolingTripView({ id, codespace }: { id?: string; codespace?: string
           onDrawingStateChange={isDrawing => dataHandle.current?.onDrawingStateChange(isDrawing)}
           departureStopId={departureStopId}
           arrivalStopId={arrivalStopId}
+          legGeometries={routeGeometry}
           ref={editableMapRef}
         />
       </Box>

--- a/src/features/plan-trip/components/CarPoolingTripData.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripData.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import { type AlertProps, Box, type SnackbarCloseReason } from '@mui/material';
 import type { Feature } from 'geojson';
+import type { RouteLegGeometries } from '../../../shared/api/routeLegChain.tsx';
 import { useNavigate } from 'react-router-dom';
 import CarPoolingTripDataForm from './CarPoolingTripDataForm.tsx';
 import { useMutateExtrajourney } from '../hooks/useMutateExtrajourney.tsx';
@@ -44,6 +45,7 @@ export interface CarPoolingTripDataProps {
   loadedFlexibleStop: (stops: Feature[]) => void;
   onDepartureStopChange: (id: string | null) => void;
   onArrivalStopChange: (id: string | null) => void;
+  onRouteGeometryChange?: (legGeometries: RouteLegGeometries) => void;
 }
 
 export type CarPoolingTripDataHandle = {
@@ -64,6 +66,7 @@ const CarPoolingTripData = forwardRef<CarPoolingTripDataHandle, CarPoolingTripDa
       loadedFlexibleStop,
       onDepartureStopChange,
       onArrivalStopChange,
+      onRouteGeometryChange,
     } = stops;
     const { authorities } = useAuthorities();
     const [snackbar, setSnackbar] = useState<SnackbarState>({
@@ -225,6 +228,7 @@ const CarPoolingTripData = forwardRef<CarPoolingTripDataHandle, CarPoolingTripDa
           mapDepartureFlexibleStop={departureStop}
           mapDestinationFlexibleStop={arrivalStop}
           tripData={tripData}
+          onRouteGeometryChange={onRouteGeometryChange}
         />
         <Snackbar
           open={snackbar.open}

--- a/src/features/plan-trip/components/CarPoolingTripDataForm.test.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.test.tsx
@@ -6,6 +6,7 @@ import type { Feature, Point } from 'geojson';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import type { CarPoolingTripDataFormData } from '../model/CarPoolingTripDataFormData';
+import type { EstimatedCall } from '../../../shared/model/EstimatedCall';
 
 const streetRoute = vi.fn();
 
@@ -64,6 +65,7 @@ const baseProps = {
   mapDepartureFlexibleStop: null as Feature | null,
   mapDestinationFlexibleStop: null as Feature | null,
   drawingStopsAllowed: true,
+  onRouteGeometryChange: vi.fn(),
 };
 
 const point = (lng: number, lat: number): Feature<Point> => ({
@@ -110,6 +112,10 @@ describe('CarPoolingTripDataForm — automatic arrival estimate', () => {
       expectedEndTime: '2026-06-01T16:00:00.000Z',
       duration: 0,
       distance: 0,
+      geometry: [
+        [10.7522, 59.9139],
+        [5.3221, 60.3913],
+      ],
     });
   });
 
@@ -143,8 +149,12 @@ describe('CarPoolingTripDataForm — automatic arrival estimate', () => {
       ).not.toBeChecked()
     );
     expect(screen.getByLabelText(/Select arrival time/i)).toBeEnabled();
-    // The saved arrival is not recomputed when auto-estimate is off.
-    expect(streetRoute).not.toHaveBeenCalled();
+    // The route may still be fetched (to draw the driving path on the map),
+    // but the saved arrival is never overwritten when auto-estimate is off.
+    const savedArrival = String(editingState().destinationDatetime);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Select arrival time/i)).toHaveValue(savedArrival)
+    );
   });
 
   it('queries OTP for the arrival when auto-estimate is on and both stops are placed', async () => {
@@ -159,5 +169,94 @@ describe('CarPoolingTripDataForm — automatic arrival estimate', () => {
       [5.3221, 60.3913],
       expect.any(String)
     );
+    // The routed expectedEndTime is written into the (disabled) arrival field.
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Arrival time \(estimated\)/i)).toHaveValue(
+        String(dayjs('2026-06-01T16:00:00.000Z'))
+      )
+    );
+  });
+
+  it('reports the routed street geometry so the map can draw the driving route', async () => {
+    const onRouteGeometryChange = vi.fn();
+    renderForm({
+      mapDepartureFlexibleStop: point(10.7522, 59.9139),
+      mapDestinationFlexibleStop: point(5.3221, 60.3913),
+      onRouteGeometryChange,
+    });
+
+    // One leg (no intermediate stops), reported as a list of leg linestrings.
+    await waitFor(() =>
+      expect(onRouteGeometryChange).toHaveBeenCalledWith([
+        [
+          [10.7522, 59.9139],
+          [5.3221, 60.3913],
+        ],
+      ])
+    );
+  });
+
+  it('routes leg by leg through non-cancelled intermediate stops', async () => {
+    // A stop's coordinate is the centroid of its flexible area, so a polygon
+    // collapsed onto a single point yields exactly that point.
+    const intermediateAt = (lng: number, lat: number, cancellation = false): EstimatedCall => ({
+      order: 2,
+      stopPointRef: 'ENT:PickupPoint:1',
+      stopPointName: 'Passenger pickup',
+      destinationDisplay: 'Bergen',
+      cancellation,
+      departureStopAssignment: {
+        expectedFlexibleArea: {
+          polygon: { exterior: { posList: `${lng} ${lat} ${lng} ${lat}` } },
+        },
+      },
+    });
+
+    renderForm({
+      initialState: {
+        ...editingState(),
+        intermediateCalls: [intermediateAt(10.9, 59.95), intermediateAt(10.5, 60.1, true)],
+      },
+      mapDepartureFlexibleStop: point(10.7522, 59.9139),
+      mapDestinationFlexibleStop: point(5.3221, 60.3913),
+    });
+
+    // The cancelled stop is skipped; the chain is origin -> pickup -> destination.
+    await waitFor(() =>
+      expect(streetRoute).toHaveBeenCalledWith([10.9, 59.95], [5.3221, 60.3913], expect.any(String))
+    );
+    expect(streetRoute).toHaveBeenCalledWith([10.7522, 59.9139], [10.9, 59.95], expect.any(String));
+    expect(streetRoute).not.toHaveBeenCalledWith(
+      expect.anything(),
+      [10.5, 60.1],
+      expect.any(String)
+    );
+  });
+
+  it("reports 'failed' when the journey planner cannot route the trip", async () => {
+    streetRoute.mockResolvedValue(null);
+    const onRouteGeometryChange = vi.fn();
+    renderForm({
+      mapDepartureFlexibleStop: point(10.7522, 59.9139),
+      mapDestinationFlexibleStop: point(5.3221, 60.3913),
+      onRouteGeometryChange,
+    });
+
+    await waitFor(() => expect(onRouteGeometryChange).toHaveBeenCalledWith('failed'));
+    // The failure is surfaced to the user, not just to the map.
+    expect(
+      screen.getByText(/Could not fetch the driving route from the journey planner/i)
+    ).toBeInTheDocument();
+  });
+
+  it('clears the route geometry when a stop is missing', () => {
+    const onRouteGeometryChange = vi.fn();
+    renderForm({
+      mapDepartureFlexibleStop: point(10.7522, 59.9139),
+      onRouteGeometryChange,
+    });
+
+    expect(onRouteGeometryChange).toHaveBeenCalledWith(null);
+    expect(streetRoute).not.toHaveBeenCalled();
   });
 });

--- a/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
@@ -34,6 +34,8 @@ import { humanizeCode } from '../../../shared/error-message/humanizeCode.tsx';
 import type { AppError } from '../../../shared/error-message/AppError.tsx';
 import type { Extrajourney } from '../../../shared/model/Extrajourney.tsx';
 import StopOccupancy from '../../../shared/components/StopOccupancy.tsx';
+import { routeLegChain, type RouteLegGeometries } from '../../../shared/api/routeLegChain.tsx';
+import loadFeatureFromFlexArea from '../util/loadFeatureFromFlexArea.tsx';
 import dayjs from 'dayjs';
 
 export interface CarPoolingTripDataFormProps {
@@ -50,6 +52,11 @@ export interface CarPoolingTripDataFormProps {
   mapDestinationFlexibleStop: Feature | null;
   drawingStopsAllowed: boolean;
   tripData?: Extrajourney | null;
+  // Reports the routed street geometry whenever it changes — one [lng, lat]
+  // linestring per leg of the trip (departure -> intermediate stops ->
+  // destination), 'failed' when the journey planner couldn't route it, or
+  // null when there is no complete route to draw.
+  onRouteGeometryChange?: (legGeometries: RouteLegGeometries) => void;
 }
 
 export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProps) {
@@ -67,6 +74,7 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     mapDestinationFlexibleStop,
     drawingStopsAllowed,
     tripData,
+    onRouteGeometryChange,
   } = props;
   // The form drives mutations (createOrUpdateExtrajourney), so restrict the
   // authority dropdown to codespaces where the user actually has write rights.
@@ -136,6 +144,9 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
   const intermediateCalls = watch('intermediateCalls');
   const tripCancellation = watch('tripCancellation');
   const streetRoute = useStreetRoute();
+  // True when the journey planner couldn't route the trip — surfaces a
+  // warning so the user knows the map line and arrival estimate are degraded.
+  const [streetRouteFailed, setStreetRouteFailed] = useState<boolean>(false);
   const [error, setError] = useState<AppError | undefined>(undefined);
   const [errorDismissed, setErrorDismissed] = useState<boolean>(false);
   const [initialStateSet, setInitialStateSet] = useState<boolean>(false);
@@ -230,50 +241,81 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
   const destinationLat = destinationFlexibleStop?.[1];
   const departureMs = departureDatetime?.isValid() ? departureDatetime.valueOf() : undefined;
 
-  useEffect(() => {
-    // Only auto-estimate when the checkbox is on (off when editing an existing
-    // trip, so its saved arrival is never silently overwritten).
-    if (!estimateArrivalAutomatically) {
-      return;
-    }
+  // The ordered stops the vehicle visits: departure, the (non-cancelled)
+  // intermediate stops at their flex-area centroids, destination. Serialised
+  // to a string so the routing effect below re-runs only when an actual
+  // coordinate changes, not on every render's fresh array identity. Null
+  // until both endpoints are placed.
+  const routeStopsKey = useMemo(() => {
     if (
       departureLng == null ||
       departureLat == null ||
       destinationLng == null ||
-      destinationLat == null ||
-      departureMs == null
+      destinationLat == null
     ) {
+      return null;
+    }
+    const via = (intermediateCalls ?? [])
+      .filter(call => !call.cancellation)
+      .map(call => loadFeatureFromFlexArea(call.departureStopAssignment?.expectedFlexibleArea))
+      .filter(feature => feature !== null)
+      .map(feature => feature.geometry.coordinates);
+    return JSON.stringify([[departureLng, departureLat], ...via, [destinationLng, destinationLat]]);
+  }, [departureLng, departureLat, destinationLng, destinationLat, intermediateCalls]);
+
+  useEffect(() => {
+    // The route is fetched whenever both endpoints and the departure are set —
+    // even with auto-estimate off — so the driving path can always be drawn on
+    // the map. It is routed leg by leg through the intermediate stops, exactly
+    // like the booking flow re-times a trip. The arrival field is only written
+    // in auto mode (off when editing an existing trip), so a saved arrival is
+    // never silently overwritten.
+    if (routeStopsKey == null || departureMs == null) {
+      // No complete route — clear any stale line from the map.
+      onRouteGeometryChange?.(null);
+      setStreetRouteFailed(false);
       return;
     }
+    const stops: Position[] = JSON.parse(routeStopsKey);
     let cancelled = false;
-    streetRoute(
-      [departureLng, departureLat],
-      [destinationLng, destinationLat],
-      dayjs(departureMs).toISOString()
-    )
-      .then(result => {
-        if (cancelled || !result?.expectedEndTime) return;
-        // Auto mode: always keep the arrival in sync with the route, so it
-        // updates whenever the origin, destination, or departure changes.
-        setValue('destinationDatetime', dayjs(result.expectedEndTime), {
-          shouldValidate: true,
-        });
+    routeLegChain(stops, dayjs(departureMs).toISOString(), streetRoute)
+      .then(chain => {
+        if (cancelled) return;
+        if (!chain) {
+          // Routed but no result — let the map fall back to straight lines.
+          onRouteGeometryChange?.('failed');
+          setStreetRouteFailed(true);
+          return;
+        }
+        onRouteGeometryChange?.(chain.legGeometries);
+        setStreetRouteFailed(false);
+        if (estimateArrivalAutomatically) {
+          // Auto mode: always keep the arrival in sync with the route, so it
+          // updates whenever a stop or the departure changes. The chained
+          // arrival accounts for any intermediate stops along the way.
+          setValue('destinationDatetime', dayjs(chain.arrivals[chain.arrivals.length - 1]), {
+            shouldValidate: true,
+          });
+        }
       })
       .catch(() => {
-        // Ignore street-routing failures; user can still set arrival manually.
+        // Street-routing failed; the map shows its straight-line fallback and
+        // the user can still set the arrival manually.
+        if (!cancelled) {
+          onRouteGeometryChange?.('failed');
+          setStreetRouteFailed(true);
+        }
       });
     return () => {
       cancelled = true;
     };
   }, [
     estimateArrivalAutomatically,
-    departureLng,
-    departureLat,
-    destinationLng,
-    destinationLat,
+    routeStopsKey,
     departureMs,
     streetRoute,
     setValue,
+    onRouteGeometryChange,
   ]);
 
   const estimatedCalls = tripData?.estimatedVehicleJourney.estimatedCalls?.estimatedCall || [];
@@ -690,6 +732,15 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
           );
         }}
       />
+      {streetRouteFailed && (
+        <Alert severity="warning">
+          Could not fetch the driving route from the journey planner. The map shows straight lines
+          between the stops instead
+          {estimateArrivalAutomatically
+            ? ', and the arrival time could not be estimated automatically.'
+            : '.'}
+        </Alert>
+      )}
       <Box display="flex" gap={1} flexWrap="wrap">
         <Button
           variant="contained"

--- a/src/shared/api/journeyPlannerStreetRoute.test.tsx
+++ b/src/shared/api/journeyPlannerStreetRoute.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import getStreetRoute from './journeyPlannerStreetRoute';
+
+const URI = 'https://api.example.com/journey-planner/v3/graphql';
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const pattern = (overrides: Record<string, unknown> = {}) => ({
+  expectedStartTime: '2026-06-01T09:00:00.000Z',
+  expectedEndTime: '2026-06-01T16:00:00.000Z',
+  duration: 25200,
+  distance: 463000,
+  // The polyline-spec reference example: decodes to
+  // [-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252].
+  legs: [{ pointsOnLink: { points: '_p~iF~ps|U_ulLnnqC_mqNvxq`@' } }],
+  ...overrides,
+});
+
+describe('getStreetRoute', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const fetchMock = () => globalThis.fetch as ReturnType<typeof vi.fn>;
+
+  it('posts a car trip query with the coordinates and departure time', async () => {
+    fetchMock().mockResolvedValueOnce(jsonResponse({ data: { trip: { tripPatterns: [] } } }));
+
+    await getStreetRoute(URI)([10.75, 59.91], [5.32, 60.39], '2026-06-01T09:00:00.000Z');
+
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock().mock.calls[0];
+    expect(url).toBe(URI);
+    expect(init.method).toBe('POST');
+    expect(init.headers['Content-Type']).toBe('application/json');
+    expect(init.headers['ET-Client-Name']).toBeTruthy();
+    const body = JSON.parse(init.body);
+    expect(body.query).toContain('trip(');
+    expect(body.query).toContain('pointsOnLink');
+    expect(body.variables).toEqual({
+      from: { coordinates: { latitude: 59.91, longitude: 10.75 } },
+      to: { coordinates: { latitude: 60.39, longitude: 5.32 } },
+      dateTime: '2026-06-01T09:00:00.000Z',
+      modes: { directMode: 'car', transportModes: [] },
+    });
+  });
+
+  it('maps the first trip pattern and decodes the leg geometry', async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({ data: { trip: { tripPatterns: [pattern()] } } })
+    );
+
+    const result = await getStreetRoute(URI)([10.75, 59.91], [5.32, 60.39], '2026-06-01T09:00Z');
+
+    expect(result).toEqual({
+      expectedStartTime: '2026-06-01T09:00:00.000Z',
+      expectedEndTime: '2026-06-01T16:00:00.000Z',
+      duration: 25200,
+      distance: 463000,
+      geometry: [
+        [-120.2, 38.5],
+        [-120.95, 40.7],
+        [-126.453, 43.252],
+      ],
+    });
+  });
+
+  it('returns null geometry when no leg carries pointsOnLink', async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({ data: { trip: { tripPatterns: [pattern({ legs: [{}] })] } } })
+    );
+
+    const result = await getStreetRoute(URI)([10.75, 59.91], [5.32, 60.39], '2026-06-01T09:00Z');
+
+    expect(result?.expectedEndTime).toBe('2026-06-01T16:00:00.000Z');
+    expect(result?.geometry).toBeNull();
+  });
+
+  it('returns null when the journey planner finds no trip pattern', async () => {
+    fetchMock().mockResolvedValueOnce(jsonResponse({ data: { trip: { tripPatterns: [] } } }));
+
+    const result = await getStreetRoute(URI)([10.75, 59.91], [5.32, 60.39], '2026-06-01T09:00Z');
+
+    expect(result).toBeNull();
+  });
+
+  it('throws on a non-OK response', async () => {
+    fetchMock().mockResolvedValueOnce(jsonResponse({}, 502));
+
+    await expect(
+      getStreetRoute(URI)([10.75, 59.91], [5.32, 60.39], '2026-06-01T09:00Z')
+    ).rejects.toThrow('502');
+  });
+});

--- a/src/shared/api/journeyPlannerStreetRoute.test.tsx
+++ b/src/shared/api/journeyPlannerStreetRoute.test.tsx
@@ -41,7 +41,7 @@ describe('getStreetRoute', () => {
     expect(url).toBe(URI);
     expect(init.method).toBe('POST');
     expect(init.headers['Content-Type']).toBe('application/json');
-    expect(init.headers['ET-Client-Name']).toBeTruthy();
+    expect(init.headers['ET-Client-Name']).toBe('entur - tadmustum');
     const body = JSON.parse(init.body);
     expect(body.query).toContain('trip(');
     expect(body.query).toContain('pointsOnLink');

--- a/src/shared/api/journeyPlannerStreetRoute.tsx
+++ b/src/shared/api/journeyPlannerStreetRoute.tsx
@@ -51,7 +51,7 @@ const getStreetRoute =
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'ET-Client-Name': 'entur - deviation-messages',
+        'ET-Client-Name': 'entur - tadmustum',
       },
       body: JSON.stringify({
         query: STREET_ROUTE_QUERY,

--- a/src/shared/api/journeyPlannerStreetRoute.tsx
+++ b/src/shared/api/journeyPlannerStreetRoute.tsx
@@ -1,11 +1,16 @@
-import { ApolloClient, gql, HttpLink, InMemoryCache } from '@apollo/client';
 import type { Position } from 'geojson';
+import decodePolyline from '../util/decodePolyline.tsx';
 
 export interface StreetRouteResult {
   expectedStartTime: string;
   expectedEndTime: string;
   duration: number;
   distance: number;
+  // The decoded street geometry of the route ([lng, lat] positions), for
+  // drawing the actual driving path on a map. Null/absent when OTP returned no
+  // leg geometry (e.g. flexible legs, which have no pointsOnLink). Optional so
+  // routing stubs that only care about times don't have to provide it.
+  geometry?: Position[] | null;
 }
 
 interface TripPattern {
@@ -13,49 +18,75 @@ interface TripPattern {
   expectedEndTime: string;
   duration: number;
   distance: number;
+  legs?: { pointsOnLink?: { points?: string | null } | null }[] | null;
 }
 
-const getStreetRoute =
-  (uri: string) =>
-  async (from: Position, to: Position, dateTime: string): Promise<StreetRouteResult | null> => {
-    const client = new ApolloClient({
-      link: new HttpLink({
-        uri,
-        headers: { 'ET-Client-Name': 'entur - deviation-messages' },
-      }),
-      cache: new InMemoryCache(),
-    });
-
-    const query = gql`
-      query StreetRoute($from: Location!, $to: Location!, $dateTime: DateTime, $modes: Modes) {
-        trip(from: $from, to: $to, dateTime: $dateTime, modes: $modes, numTripPatterns: 1) {
-          tripPatterns {
-            expectedStartTime
-            expectedEndTime
-            duration
-            distance
+// A direct car route between two points, asking for the leg geometry
+// (encoded polyline) on top of the times.
+const STREET_ROUTE_QUERY = `
+  query StreetRoute($from: Location!, $to: Location!, $dateTime: DateTime, $modes: Modes) {
+    trip(from: $from, to: $to, dateTime: $dateTime, modes: $modes, numTripPatterns: 1) {
+      tripPatterns {
+        expectedStartTime
+        expectedEndTime
+        duration
+        distance
+        legs {
+          pointsOnLink {
+            points
           }
         }
       }
-    `;
+    }
+  }
+`;
 
-    const variables = {
-      from: { coordinates: { latitude: from[1], longitude: from[0] } },
-      to: { coordinates: { latitude: to[1], longitude: to[0] } },
-      dateTime,
-      modes: { directMode: 'car', transportModes: [] },
+// Plans a single car street route between two points via the journey planner
+// GraphQL API. Plain fetch — a GraphQL request is just a POST of
+// { query, variables }, and a client library buys nothing for one query.
+const getStreetRoute =
+  (uri: string) =>
+  async (from: Position, to: Position, dateTime: string): Promise<StreetRouteResult | null> => {
+    const response = await fetch(uri, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'ET-Client-Name': 'entur - deviation-messages',
+      },
+      body: JSON.stringify({
+        query: STREET_ROUTE_QUERY,
+        variables: {
+          from: { coordinates: { latitude: from[1], longitude: from[0] } },
+          to: { coordinates: { latitude: to[1], longitude: to[0] } },
+          dateTime,
+          modes: { directMode: 'car', transportModes: [] },
+        },
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`Street route request failed: ${response.status}`);
+    }
+
+    const body = (await response.json()) as {
+      data?: { trip?: { tripPatterns?: TripPattern[] } };
     };
-
-    const result = await client.query({ query, variables });
-    const patterns: TripPattern[] | undefined = result.data?.trip?.tripPatterns;
+    const patterns = body.data?.trip?.tripPatterns;
     if (!patterns || patterns.length === 0) return null;
 
     const pattern = patterns[0];
+    // A direct car route is a single leg, but concatenate defensively in case
+    // OTP ever splits it. Legs without geometry are simply skipped.
+    const geometry = (pattern.legs ?? [])
+      .map(leg => leg?.pointsOnLink?.points)
+      .filter((points): points is string => !!points)
+      .flatMap(decodePolyline);
+
     return {
       expectedStartTime: pattern.expectedStartTime,
       expectedEndTime: pattern.expectedEndTime,
       duration: pattern.duration,
       distance: pattern.distance,
+      geometry: geometry.length >= 2 ? geometry : null,
     };
   };
 

--- a/src/shared/api/prepareBookingData.test.tsx
+++ b/src/shared/api/prepareBookingData.test.tsx
@@ -504,6 +504,24 @@ describe('prepareBookingData', () => {
         '2026-06-01T09:40:00.000Z', // Dropoff
         '2026-06-01T09:50:00.000Z', // Destination
       ]);
+      // One geometry per leg. The stub returns no street geometry, so each
+      // leg falls back to the straight segment between its stops — still
+      // drawable end to end.
+      expect(preview!.legGeometries).toHaveLength(preview!.calls.length - 1);
+      preview!.legGeometries!.forEach(leg => expect(leg).toHaveLength(2));
+    });
+
+    it('returns no leg geometries when a leg cannot be routed', async () => {
+      const failingRouter: RouteLeg = async () => null;
+
+      const preview = await routedBookingPreview(
+        tripWithIntermediates(),
+        baseBooking({ pickupCoordinates: [10.3, 60], dropoffCoordinates: [10.7, 60] }),
+        failingRouter
+      );
+
+      expect(preview).not.toBeNull();
+      expect(preview!.legGeometries).toBeNull();
     });
   });
 });

--- a/src/shared/api/prepareBookingData.tsx
+++ b/src/shared/api/prepareBookingData.tsx
@@ -8,7 +8,11 @@ import {
   insertStopsByShortestPath,
 } from '../../features/passenger-booking/util/shortestPath.tsx';
 import loadFeatureFromFlexArea from '../../features/plan-trip/util/loadFeatureFromFlexArea.tsx';
-import type { StreetRouteResult } from './journeyPlannerStreetRoute.tsx';
+import { routeLegChain, type RouteLeg } from './routeLegChain.tsx';
+
+// Re-exported for callers that pass the street router into the booking
+// helpers; the type itself lives with routeLegChain.
+export type { RouteLeg };
 
 export interface PassengerBookingData {
   tripId: string;
@@ -19,14 +23,6 @@ export interface PassengerBookingData {
   numberOfPassengers: number;
   passengerDeviationBudget?: number;
 }
-
-// Plans a single car leg between two points departing at `dateTime`. Same
-// signature as the journey-planner street route used when planning a trip.
-export type RouteLeg = (
-  from: Position,
-  to: Position,
-  dateTime: string
-) => Promise<StreetRouteResult | null>;
 
 export async function prepareBookingData(
   originalTrip: Extrajourney,
@@ -45,7 +41,7 @@ export async function prepareBookingData(
   // Over-capacity bookings are allowed (the UI warns about them), so we don't
   // reject here — occupancy is still computed so every stop reflects the load.
   const assembled = assembleBooking(originalTrip, bookingData);
-  const orderedCalls = await routeAssembledCalls(assembled, bookingData, routeLeg);
+  const { calls: orderedCalls } = await routeAssembledCalls(assembled, bookingData, routeLeg);
 
   const updatedTrip: Extrajourney = {
     id: originalTrip.id,
@@ -70,11 +66,13 @@ export async function prepareBookingData(
 // departure. A detour for a pickup pushes back every downstream stop, and each
 // stop's latestExpectedArrivalTime shifts with it. Without a router (or when a
 // stop lacks a coordinate) the assembled estimate is returned unchanged.
+// Also yields the routed street geometry per leg (null when not routed), so
+// the booking map can draw the actual driving path.
 async function routeAssembledCalls(
   assembled: AssembledBooking,
   bookingData: PassengerBookingData,
   routeLeg?: RouteLeg
-): Promise<EstimatedCall[]> {
+): Promise<{ calls: EstimatedCall[]; legGeometries: Position[][] | null }> {
   if (routeLeg && assembled.canOrderByPath) {
     return applyRoutedTimes(
       assembled.orderedCalls,
@@ -84,7 +82,7 @@ async function routeAssembledCalls(
       bookingData.passengerDeviationBudget
     );
   }
-  return assembled.orderedCalls;
+  return { calls: assembled.orderedCalls, legGeometries: null };
 }
 
 export interface BookingRoutePreview {
@@ -98,6 +96,10 @@ export interface BookingRoutePreview {
   // can label it with the same text it shows in the route list. Lets the UI
   // flag over-capacity live instead of throwing.
   overCapacityStopIndex: number | null;
+  // Routed street geometry per leg of the previewed route (calls[i] ->
+  // calls[i+1]), for drawing the actual driving path on the booking map.
+  // Null when the preview wasn't routed (sync preview, routing unavailable).
+  legGeometries: Position[][] | null;
 }
 
 // Synchronous preview of what a booking would do to the trip route: the new
@@ -121,6 +123,7 @@ export function previewBookingRoute(
     pickupStopRef: assembled.pickupStopRef,
     dropoffStopRef: assembled.dropoffStopRef,
     overCapacityStopIndex: assembled.exceededAt?.index ?? null,
+    legGeometries: null,
   };
 }
 
@@ -139,12 +142,13 @@ export async function routedBookingPreview(
   } catch {
     return null;
   }
-  const calls = await routeAssembledCalls(assembled, bookingData, routeLeg);
+  const { calls, legGeometries } = await routeAssembledCalls(assembled, bookingData, routeLeg);
   return {
     calls: renumberCalls(calls),
     pickupStopRef: assembled.pickupStopRef,
     dropoffStopRef: assembled.dropoffStopRef,
     overCapacityStopIndex: assembled.exceededAt?.index ?? null,
+    legGeometries,
   };
 }
 
@@ -403,28 +407,24 @@ function applyOccupancy(
 
 // Re-times the sequence using real car-driving durations. Routes each leg in
 // turn from the driver's departure, accumulating arrival times. Returns the
-// calls unchanged if there is no departure time or any leg can't be planned,
-// so a routing hiccup never yields a half-updated schedule.
+// calls unchanged (and no geometry) if there is no departure time or any leg
+// can't be planned, so a routing hiccup never yields a half-updated schedule
+// or a half-drawn route.
 async function applyRoutedTimes(
   orderedCalls: EstimatedCall[],
   coords: LngLat[],
   originDeparture: string | undefined,
   routeLeg: RouteLeg,
   passengerDeviationBudget?: number
-): Promise<EstimatedCall[]> {
-  if (!originDeparture) return orderedCalls;
+): Promise<{ calls: EstimatedCall[]; legGeometries: Position[][] | null }> {
+  if (!originDeparture) return { calls: orderedCalls, legGeometries: null };
 
-  const arrivals: string[] = [];
-  let currentTime = originDeparture;
-  for (let i = 0; i < orderedCalls.length - 1; i++) {
-    const route = await routeLeg(coords[i], coords[i + 1], currentTime);
-    if (!route) return orderedCalls;
-    arrivals[i + 1] = route.expectedEndTime;
-    currentTime = route.expectedEndTime;
-  }
+  const chain = await routeLegChain(coords, originDeparture, routeLeg);
+  if (!chain) return { calls: orderedCalls, legGeometries: null };
+  const { arrivals, legGeometries } = chain;
 
   const lastIndex = orderedCalls.length - 1;
-  return orderedCalls.map((call, index) => {
+  const calls = orderedCalls.map((call, index) => {
     if (index === 0) {
       // Origin keeps its planned departure; mirror it onto the expected time.
       return {
@@ -447,6 +447,7 @@ async function applyRoutedTimes(
     }
     return updated;
   });
+  return { calls, legGeometries };
 }
 
 // New latest-arrival deadline for a stop after its scheduled time moved to

--- a/src/shared/api/routeLegChain.test.tsx
+++ b/src/shared/api/routeLegChain.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import dayjs from 'dayjs';
+import { routeLegChain, type RouteLeg } from './routeLegChain';
+import type { Position } from 'geojson';
+
+const A: Position = [10.0, 59.0];
+const B: Position = [10.5, 59.5];
+const C: Position = [11.0, 60.0];
+
+// Each leg takes 10 minutes and routes via a midpoint, so the geometry is
+// distinguishable from the straight segment between the stops.
+const tenMinPerLeg: RouteLeg = async (from, to, dateTime) => ({
+  expectedStartTime: dateTime,
+  expectedEndTime: dayjs(dateTime).add(10, 'minute').toISOString(),
+  duration: 600,
+  distance: 1000,
+  geometry: [from, [(from[0] + to[0]) / 2, (from[1] + to[1]) / 2], to],
+});
+
+describe('routeLegChain', () => {
+  it('chains arrival times leg by leg from the departure', async () => {
+    const chain = await routeLegChain([A, B, C], '2026-06-01T08:00:00.000Z', tenMinPerLeg);
+
+    expect(chain?.arrivals).toEqual([
+      '2026-06-01T08:00:00.000Z',
+      '2026-06-01T08:10:00.000Z',
+      '2026-06-01T08:20:00.000Z',
+    ]);
+    expect(chain?.legGeometries).toEqual([
+      [A, [10.25, 59.25], B],
+      [B, [10.75, 59.75], C],
+    ]);
+  });
+
+  it('falls back to the straight segment for a leg without geometry', async () => {
+    const noGeometry: RouteLeg = async (_from, _to, dateTime) => ({
+      expectedStartTime: dateTime,
+      expectedEndTime: dayjs(dateTime).add(10, 'minute').toISOString(),
+      duration: 600,
+      distance: 1000,
+    });
+
+    const chain = await routeLegChain([A, B], '2026-06-01T08:00:00.000Z', noGeometry);
+
+    expect(chain?.legGeometries).toEqual([[A, B]]);
+  });
+
+  it('returns null when any leg cannot be planned', async () => {
+    const failsSecondLeg = vi
+      .fn<RouteLeg>()
+      .mockImplementationOnce(tenMinPerLeg)
+      .mockResolvedValueOnce(null);
+
+    const chain = await routeLegChain([A, B, C], '2026-06-01T08:00:00.000Z', failsSecondLeg);
+
+    expect(chain).toBeNull();
+    expect(failsSecondLeg).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/shared/api/routeLegChain.tsx
+++ b/src/shared/api/routeLegChain.tsx
@@ -1,0 +1,51 @@
+import type { Position } from 'geojson';
+import type { StreetRouteResult } from './journeyPlannerStreetRoute.tsx';
+
+// Plans a single car leg between two points departing at `dateTime`. The
+// journey-planner street route (api.getStreetRoute) has this signature.
+export type RouteLeg = (
+  from: Position,
+  to: Position,
+  dateTime: string
+) => Promise<StreetRouteResult | null>;
+
+// What a map should draw for a routed path: the leg linestrings when routing
+// succeeded, 'failed' when the journey planner couldn't route it (the map
+// shows its straight-line fallback), or null when there is nothing to draw
+// yet (no stops placed, or a route still being computed — drawing the
+// straight line first and snapping to the real route afterwards looks bad).
+export type RouteLegGeometries = Position[][] | 'failed' | null;
+
+export interface RoutedLegChain {
+  // Arrival time at each stop, aligned by index with the input coords;
+  // arrivals[0] is the departure time itself.
+  arrivals: string[];
+  // Street geometry per leg (coords[i] -> coords[i+1]). A leg whose route
+  // came back without geometry falls back to the straight segment between its
+  // stops, so the chain can always be drawn end-to-end.
+  legGeometries: Position[][];
+}
+
+// Routes each consecutive leg of a multi-stop sequence in turn, departing each
+// stop the moment the vehicle arrives (no dwell), and accumulates arrival
+// times and street geometries. All-or-nothing: returns null when any leg
+// can't be planned, so callers never get a half-routed chain.
+export async function routeLegChain(
+  coords: Position[],
+  departureTime: string,
+  routeLeg: RouteLeg
+): Promise<RoutedLegChain | null> {
+  const arrivals: string[] = [departureTime];
+  const legGeometries: Position[][] = [];
+  let currentTime = departureTime;
+  for (let i = 0; i < coords.length - 1; i++) {
+    const route = await routeLeg(coords[i], coords[i + 1], currentTime);
+    if (!route) return null;
+    arrivals.push(route.expectedEndTime);
+    legGeometries.push(
+      route.geometry && route.geometry.length >= 2 ? route.geometry : [coords[i], coords[i + 1]]
+    );
+    currentTime = route.expectedEndTime;
+  }
+  return { arrivals, legGeometries };
+}

--- a/src/shared/components/EditableMap.tsx
+++ b/src/shared/components/EditableMap.tsx
@@ -19,6 +19,8 @@ import {
 } from 'react';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import type { Feature, Point, LineString } from 'geojson';
+import type { RouteLegGeometries } from '../api/routeLegChain.tsx';
+import RouteLineLayers from './RouteLineLayers.tsx';
 import { v4 as uuidv4 } from 'uuid';
 import { MAPBOXDRAW_DEFAULT_CONSTRUCTOR } from '../util/MAPBOXDRAW_DEFAULT_CONSTRUCTOR.tsx';
 import type { IControl } from 'maplibre-gl';
@@ -34,6 +36,11 @@ export type EditableMapCallbacks = {
 export type EditableMapProps = EditableMapCallbacks & {
   departureStopId?: string | null;
   arrivalStopId?: string | null;
+  // The routed driving path of the trip, one [lng, lat] linestring per leg
+  // (through any intermediate stops), drawn as a solid line. 'failed' draws
+  // the straight dashed line between the stops as a fallback; null draws
+  // nothing (no stops yet, or a route still being computed).
+  legGeometries?: RouteLegGeometries;
 };
 
 export type MapModes = MapMode[keyof MapMode];
@@ -54,7 +61,7 @@ export interface MapMode {
 }
 
 const EditableMap = forwardRef<EditableMapHandle, EditableMapProps>(
-  ({ departureStopId, arrivalStopId, ...props }, ref) => {
+  ({ departureStopId, arrivalStopId, legGeometries, ...props }, ref) => {
     const mapRef = useRef<null | MapRef>(null);
 
     // Tracked as a ref because it's only inspected in event handlers and the
@@ -241,7 +248,7 @@ const EditableMap = forwardRef<EditableMapHandle, EditableMapProps>(
       };
     }, [featureArray]);
 
-    const routeLine = createRouteLineString();
+    const fallbackRouteLine = createRouteLineString();
 
     useImperativeHandle(ref, () => ({
       addFeatures,
@@ -327,19 +334,7 @@ const EditableMap = forwardRef<EditableMapHandle, EditableMapProps>(
         })}
 
         {/* Route Line */}
-        {routeLine && (
-          <Source type="geojson" data={routeLine}>
-            <Layer
-              id="route-line"
-              type="line"
-              paint={{
-                'line-color': '#FF9800',
-                'line-width': 4,
-                'line-dasharray': [2, 2],
-              }}
-            />
-          </Source>
-        )}
+        <RouteLineLayers legGeometries={legGeometries} fallbackLine={fallbackRouteLine} />
 
         {/* Stop Markers — numbered circles matching the booking map. */}
         {featureArray.map((feature, index) => {

--- a/src/shared/components/RouteLineLayers.test.tsx
+++ b/src/shared/components/RouteLineLayers.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Feature, LineString } from 'geojson';
+import type { ComponentProps, ReactNode } from 'react';
+
+// Stub react-map-gl so the layers render as inspectable DOM nodes instead of
+// requiring a WebGL map context (unavailable under jsdom).
+vi.mock('react-map-gl/maplibre', () => ({
+  Source: ({ children, data }: { children: ReactNode; data: unknown }) => (
+    <div data-testid="source" data-geojson={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  Layer: (props: { id: string; paint: Record<string, unknown> }) => (
+    <div data-testid={props.id} data-paint={JSON.stringify(props.paint)} />
+  ),
+}));
+
+import RouteLineLayers from './RouteLineLayers';
+
+const fallbackLine: Feature<LineString> = {
+  type: 'Feature',
+  properties: { type: 'route' },
+  geometry: {
+    type: 'LineString',
+    coordinates: [
+      [10, 59],
+      [11, 60],
+    ],
+  },
+};
+
+const legs = [
+  [
+    [10, 59],
+    [10.4, 59.6],
+    [10.5, 59.5],
+  ],
+  [
+    [10.5, 59.5],
+    [11, 60],
+  ],
+];
+
+const renderLayers = (legGeometries: ComponentProps<typeof RouteLineLayers>['legGeometries']) =>
+  render(<RouteLineLayers legGeometries={legGeometries} fallbackLine={fallbackLine} />);
+
+describe('RouteLineLayers', () => {
+  it('draws the routed legs as a solid cased line', () => {
+    renderLayers(legs);
+
+    const geojson = JSON.parse(screen.getByTestId('source').dataset.geojson!);
+    expect(geojson.geometry).toEqual({ type: 'MultiLineString', coordinates: legs });
+
+    expect(screen.getByTestId('route-line-casing')).toBeInTheDocument();
+    const paint = JSON.parse(screen.getByTestId('route-line').dataset.paint!);
+    expect(paint['line-dasharray']).toBeUndefined();
+  });
+
+  it("draws the dashed fallback line when routing failed ('failed')", () => {
+    renderLayers('failed');
+
+    const geojson = JSON.parse(screen.getByTestId('source').dataset.geojson!);
+    expect(geojson.geometry.type).toBe('LineString');
+
+    const paint = JSON.parse(screen.getByTestId('route-line').dataset.paint!);
+    expect(paint['line-dasharray']).toEqual([2, 2]);
+  });
+
+  it('draws nothing while no route exists yet (null)', () => {
+    renderLayers(null);
+
+    expect(screen.queryByTestId('source')).not.toBeInTheDocument();
+  });
+
+  it('draws nothing when the routed legs are all degenerate', () => {
+    renderLayers([[[10, 59]]]);
+
+    expect(screen.queryByTestId('source')).not.toBeInTheDocument();
+  });
+});

--- a/src/shared/components/RouteLineLayers.tsx
+++ b/src/shared/components/RouteLineLayers.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import { Source, Layer } from 'react-map-gl/maplibre';
+import type { Feature, LineString, MultiLineString } from 'geojson';
+import type { RouteLegGeometries } from '../api/routeLegChain.tsx';
+
+export interface RouteLineLayersProps {
+  // The routed driving path, one [lng, lat] linestring per leg ('failed' when
+  // routing failed, null while routing / nothing to draw).
+  legGeometries?: RouteLegGeometries;
+  // Straight line between the stops, drawn dashed when routing failed.
+  fallbackLine: Feature<LineString> | null;
+}
+
+// The route line shared by the trip maps: the routed driving path as a solid
+// line, the straight fallback line dashed when routing failed, and nothing
+// while a route is still being computed (drawing the straight line first and
+// snapping to the real route afterwards looks glitchy). Navigation blue over
+// a white casing: OSM Carto draws roads in orange/yellow tones, so the route
+// needs a hue the basemap never uses, and the casing keeps it readable on top
+// of any road.
+export default function RouteLineLayers({ legGeometries, fallbackLine }: RouteLineLayersProps) {
+  const drivingRouteLine = useMemo((): Feature<MultiLineString> | null => {
+    if (!Array.isArray(legGeometries)) return null;
+    const legs = legGeometries.filter(leg => leg.length >= 2);
+    if (legs.length === 0) return null;
+    return {
+      type: 'Feature',
+      properties: { type: 'route' },
+      geometry: { type: 'MultiLineString', coordinates: legs },
+    };
+  }, [legGeometries]);
+
+  const routeLine = drivingRouteLine ?? (legGeometries === 'failed' ? fallbackLine : null);
+  if (!routeLine) return null;
+
+  return (
+    <Source type="geojson" data={routeLine}>
+      {/* Solid casing also under the dashed fallback — it reads as blue
+          dashes on a white band, keeping it visible over any road. */}
+      <Layer
+        id="route-line-casing"
+        type="line"
+        layout={{ 'line-cap': 'round', 'line-join': 'round' }}
+        paint={{ 'line-color': '#FFFFFF', 'line-width': 7 }}
+      />
+      <Layer
+        id="route-line"
+        type="line"
+        layout={{ 'line-cap': 'round', 'line-join': 'round' }}
+        paint={
+          drivingRouteLine
+            ? { 'line-color': '#1A73E8', 'line-width': 4.5 }
+            : { 'line-color': '#1A73E8', 'line-width': 4, 'line-dasharray': [2, 2] }
+        }
+      />
+    </Source>
+  );
+}

--- a/src/shared/util/decodePolyline.test.tsx
+++ b/src/shared/util/decodePolyline.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import decodePolyline from './decodePolyline';
+
+describe('decodePolyline', () => {
+  it('decodes the reference example from the polyline algorithm spec', () => {
+    // https://developers.google.com/maps/documentation/utilities/polylinealgorithm
+    // encodes (38.5,-120.2), (40.7,-120.95), (43.252,-126.453).
+    const positions = decodePolyline('_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+
+    expect(positions).toEqual([
+      [-120.2, 38.5],
+      [-120.95, 40.7],
+      [-126.453, 43.252],
+    ]);
+  });
+
+  it('returns an empty array for an empty string', () => {
+    expect(decodePolyline('')).toEqual([]);
+  });
+});

--- a/src/shared/util/decodePolyline.tsx
+++ b/src/shared/util/decodePolyline.tsx
@@ -1,0 +1,31 @@
+import type { Position } from 'geojson';
+
+// Decodes a Google encoded polyline into GeoJSON positions ([lng, lat]).
+// OTP's PointsOnLink.points uses this format at the standard 1e5 precision
+// (see OpenTripPlanner's PolylineEncoder), so no precision parameter is needed.
+export default function decodePolyline(encoded: string): Position[] {
+  const positions: Position[] = [];
+  let index = 0;
+  let lat = 0;
+  let lng = 0;
+
+  const readDelta = (): number => {
+    let byte;
+    let shift = 0;
+    let result = 0;
+    do {
+      byte = encoded.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+    return result & 1 ? ~(result >> 1) : result >> 1;
+  };
+
+  while (index < encoded.length) {
+    lat += readDelta();
+    lng += readDelta();
+    positions.push([lng / 1e5, lat / 1e5]);
+  }
+
+  return positions;
+}


### PR DESCRIPTION
Fetch the leg geometry (pointsOnLink encoded polyline) from the journey planner street-route query and draw the actual driving route instead of straight lines between stops:

- plan/edit map routes leg by leg through the (non-cancelled) intermediate stops via the new shared routeLegChain; the auto-estimated arrival now accounts for intermediate stops as well
- booking preview exposes its per-leg routed geometries (already fetched for re-timing, previously discarded); the booking map also routes the trip's own path before pickup/dropoff are selected
- the straight dashed line is now only a failure fallback (nothing is drawn while a route is computing), and routing failures surface a warning on both pages
- route line restyled to navigation blue over a white casing so it stays readable on OSM Carto's orange/yellow roads; rendering shared via the new RouteLineLayers component
- journeyPlannerStreetRoute rewritten from a per-call ApolloClient to a plain fetch (same wire format), making it unit-testable