### PR TITLE
Add Firebase tst (staging) deployment after dev

### DIFF
--- a/.github/environments/config-tst.json
+++ b/.github/environments/config-tst.json
@@ -1,0 +1,16 @@
+{
+  "carpool-messages-api": "https://api.staging.entur.io/carpool-messages/v1/graphql",
+  "journey-planner-api": "https://api.staging.entur.io/journey-planner/v3/graphql",
+  "applicationEnv": "staging",
+  "claimsNamespace": "https://ror.entur.io/role_assignments",
+  "preferredNameNamespace": "https://ror.entur.io/preferred_name",
+  "oidcConfig": {
+    "authority": "https://partner.staging.entur.org",
+    "client_id": "REPLACE_WITH_STAGING_CLIENT_ID",
+    "extraQueryParams": {
+      "audience": "https://api.staging.entur.io"
+    }
+  },
+  "showErrorDetails": false,
+  "themeFilePath": "/theme-tst.json"
+}

--- a/.github/environments/theme-tst.json
+++ b/.github/environments/theme-tst.json
@@ -1,0 +1,29 @@
+{
+  "applicationName": "Entur Car Pooling PoC",
+  "companyName": "Entur",
+  "palette": {
+    "primary": { "main": "#181C56" },
+    "secondary": { "main": "#ff5959" },
+    "background": { "default": "#ffffff" },
+    "info": { "main": "#ff5959" },
+    "action": { "hover": "#aeb7e2", "active": "#aeb7e2" }
+  },
+  "typography": {
+    "fontFamily": " \"Nationale\", Arial, \"Gotham Rounded\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, Oxygen-Sans, Ubuntu, Cantarell, \"Helvetica Neue\", sans-serif;",
+    "h1": { "fontSize": "3rem" }
+  },
+  "shape": {
+    "borderRadius": 4
+  },
+  "components": {
+    "MuiButton": {
+      "styleOverrides": {
+        "root": {
+          "textTransform": "none"
+        }
+      }
+    }
+  },
+  "logoUrl": "/assets/entur-logo.png",
+  "logoHeight": 20
+}

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -25,7 +25,7 @@ jobs:
         run: cp .github/environments/config-dev.json dist/config.json
       - name: Copy theme config
         run: cp .github/environments/theme-dev.json dist/theme-dev.json
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_TADMUSTUM_DEV }}
@@ -49,7 +49,7 @@ jobs:
         run: cp .github/environments/config-tst.json dist/config.json
       - name: Copy theme config
         run: cp .github/environments/theme-tst.json dist/theme-tst.json
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_TADMUSTUM_TST }}

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -31,3 +31,27 @@ jobs:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_TADMUSTUM_DEV }}
           channelId: live
           projectId: ent-tadmustum-dev
+
+  deploy_tst:
+    needs: build_and_deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Copy bootstrap config
+        run: cp .github/environments/config-tst.json dist/config.json
+      - name: Copy theme config
+        run: cp .github/environments/theme-tst.json dist/theme-tst.json
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_TADMUSTUM_TST }}
+          channelId: live
+          projectId: ent-tadmustum-tst

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm run test:run
       - name: Build
         run: npm run build
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_TADMUSTUM_DEV }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ public/theme-*.json
 # Claude AI
 .claude/
 thoughts/
+.playwright-mcp/


### PR DESCRIPTION
- config-tst.json / theme-tst.json: staging bootstrap config (api.staging.entur.io, partner.staging.entur.org). OIDC client_id is a placeholder for now.
- firebase-hosting-merge.yml: deploy_tst job that runs after build_and_deploy and deploys to ent-tadmustum-tst using FIREBASE_SERVICE_ACCOUNT_ENT_TADMUSTUM_TST.
- .gitignore: ignore .playwright-mcp/ local MCP artifacts.