### PR TITLE
Set staging OIDC client_id for tadmustum tst

### DIFF
--- a/.github/environments/config-tst.json
+++ b/.github/environments/config-tst.json
@@ -6,7 +6,7 @@
   "preferredNameNamespace": "https://ror.entur.io/preferred_name",
   "oidcConfig": {
     "authority": "https://partner.staging.entur.org",
-    "client_id": "REPLACE_WITH_STAGING_CLIENT_ID",
+    "client_id": "ToKCcec3JywHuCYrxUB9a2qZlBuhaBXd",
     "extraQueryParams": {
       "audience": "https://api.staging.entur.io"
     }


### PR DESCRIPTION
Replaces the placeholder with the staging partner SPA client_id provisioned in partner.staging.entur.org, enabling login on the tst deployment.