### PR TITLE
Add Duplicate action to clone a trip into a new one

### DIFF
--- a/src/features/plan-trip/CarPoolingTrip.tsx
+++ b/src/features/plan-trip/CarPoolingTrip.tsx
@@ -7,18 +7,37 @@ import CarPoolingTripData, {
 } from './components/CarPoolingTripData.tsx';
 import { type EditableMapHandle } from '../../shared/components/EditableMap.tsx';
 import EditableMap from '../../shared/components/EditableMap.tsx';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import type { Feature } from 'geojson';
 import type { RouteLegGeometries } from '../../shared/api/routeLegChain.tsx';
 
 export default function CarPoolingTrip() {
   const { codespace, id } = useParams();
-  // Remount on id change so a fresh plan-trip page loads when switching trips
-  // (or from editing back to a blank new trip).
-  return <CarPoolingTripView key={id ?? 'new'} id={id} codespace={codespace} />;
+  // `?duplicate=true` reuses the edit route but tells the form to clone the
+  // loaded trip into a brand-new one (fresh id/code) instead of editing it.
+  const [searchParams] = useSearchParams();
+  const duplicate = searchParams.get('duplicate') === 'true';
+  // Remount on id (and duplicate mode) change so a fresh plan-trip page loads
+  // when switching trips, duplicating, or going back to a blank new trip.
+  return (
+    <CarPoolingTripView
+      key={`${id ?? 'new'}${duplicate ? ':duplicate' : ''}`}
+      id={id}
+      codespace={codespace}
+      duplicate={duplicate}
+    />
+  );
 }
 
-function CarPoolingTripView({ id, codespace }: { id?: string; codespace?: string }) {
+function CarPoolingTripView({
+  id,
+  codespace,
+  duplicate,
+}: {
+  id?: string;
+  codespace?: string;
+  duplicate?: boolean;
+}) {
   const theme = useTheme();
 
   const editableMapRef = useRef<EditableMapHandle>(null);
@@ -70,6 +89,7 @@ function CarPoolingTripView({ id, codespace }: { id?: string; codespace?: string
         <CarPoolingTripData
           tripId={id}
           codespace={codespace}
+          duplicate={duplicate}
           ref={dataHandle}
           onAddFlexibleStop={() => editableMapRef.current?.drawFeature()}
           onRemoveFlexibleStop={id => editableMapRef.current?.removeFeature(id)}

--- a/src/features/plan-trip/components/CarPoolingTripData.test.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripData.test.tsx
@@ -12,8 +12,10 @@ vi.mock('../hooks/useQueryOneExtraJourney', () => ({
   useQueryExtraJourney: () => queryOneExtraJourney,
 }));
 
+// Stable mutation mock so the duplicate test can assert what gets saved.
+const { mutate } = vi.hoisted(() => ({ mutate: vi.fn() }));
 vi.mock('../hooks/useMutateExtrajourney', () => ({
-  useMutateExtrajourney: () => vi.fn(),
+  useMutateExtrajourney: () => mutate,
 }));
 
 // useAuthorities pairs codespaces to NeTEx authority ids; the component waits
@@ -26,14 +28,23 @@ vi.mock('../../../shared/hooks/useAuthorities', () => ({
   }),
 }));
 
-// Stub the heavy form (MUI fields, date pickers, schema). The reset behaviour
-// lives in CarPoolingTripData, so we only need a way to fire onResetCallback
-// and observe whether a trip was loaded.
+// Stub the heavy form (MUI fields, date pickers, schema). The reset/identity
+// logic lives in CarPoolingTripData, so we expose the pre-filled initialState
+// and a way to fire onReset/onSubmit, plus whether a trip was loaded.
 vi.mock('./CarPoolingTripDataForm', () => ({
-  default: (props: { onResetCallback: () => void; tripData: unknown }) => (
+  default: (props: {
+    onResetCallback: () => void;
+    onSubmitCallback: (data: CarPoolingTripDataFormData) => void;
+    initialState?: CarPoolingTripDataFormData;
+    tripData: unknown;
+  }) => (
     <div>
       <button onClick={() => props.onResetCallback()}>reset</button>
+      <button onClick={() => props.onSubmitCallback(props.initialState!)}>submit</button>
       <span data-testid="editing">{props.tripData ? 'yes' : 'no'}</span>
+      <span data-testid="trip-id">{props.initialState?.id ?? 'none'}</span>
+      <span data-testid="code">{props.initialState?.estimatedVehicleJourneyCode ?? 'none'}</span>
+      <span data-testid="line-ref">{props.initialState?.lineRef ?? 'none'}</span>
     </div>
   ),
 }));
@@ -114,5 +125,50 @@ describe('CarPoolingTripData reset behaviour', () => {
     // No trip to restore: the map is wiped and nothing is reloaded.
     expect(props.onRemoveAllFlexibleStops).toHaveBeenCalledTimes(1);
     expect(props.loadedFlexibleStop).not.toHaveBeenCalled();
+  });
+});
+
+describe('CarPoolingTripData duplicate behaviour', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pre-fills from the source trip but mints a fresh identity', async () => {
+    queryOneExtraJourney.mockResolvedValue({ data: { extraJourney: journeyFixture() } });
+    const props = mapCallbacks();
+
+    renderWithRouter(<CarPoolingTripData tripId={TRIP_ID} codespace="ENT" duplicate {...props} />);
+
+    // The source trip is still loaded (its stops are drawn) to pre-fill the form.
+    await waitFor(() => expect(props.loadedFlexibleStop).toHaveBeenCalledTimes(1));
+
+    // ...but its identity is replaced: the source id is dropped and a fresh
+    // journey code / lineRef are minted under the same codespace.
+    expect(screen.getByTestId('trip-id')).toHaveTextContent('none');
+    const code = screen.getByTestId('code').textContent ?? '';
+    const lineRef = screen.getByTestId('line-ref').textContent ?? '';
+    expect(code).toMatch(/^ENT:ServiceJourney:/);
+    expect(code).not.toBe(TRIP_ID);
+    expect(lineRef).toMatch(/^ENT:CarPooling:/);
+  });
+
+  it('saves as a new trip rather than overwriting the source on submit', async () => {
+    queryOneExtraJourney.mockResolvedValue({ data: { extraJourney: journeyFixture() } });
+    mutate.mockResolvedValue({ data: 'ENT:ServiceJourney:new' });
+    const props = mapCallbacks();
+
+    renderWithRouter(<CarPoolingTripData tripId={TRIP_ID} codespace="ENT" duplicate {...props} />);
+
+    await waitFor(() => expect(props.loadedFlexibleStop).toHaveBeenCalledTimes(1));
+    const code = screen.getByTestId('code').textContent ?? '';
+
+    fireEvent.click(screen.getByText('submit'));
+
+    // The mutation must carry no id (so nunamnir creates a new trip) and the
+    // freshly-minted code — never the source id, which would overwrite it.
+    await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+    const saved = mutate.mock.calls[0][0] as CarPoolingTripDataFormData;
+    expect(saved.id).toBeUndefined();
+    expect(saved.estimatedVehicleJourneyCode).toBe(code);
   });
 });

--- a/src/features/plan-trip/components/CarPoolingTripData.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripData.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import { type AlertProps, Box, type SnackbarCloseReason } from '@mui/material';
 import type { Feature } from 'geojson';
+import { v4 as uuidv4 } from 'uuid';
 import type { RouteLegGeometries } from '../../../shared/api/routeLegChain.tsx';
 import { useNavigate } from 'react-router-dom';
 import CarPoolingTripDataForm from './CarPoolingTripDataForm.tsx';
@@ -38,6 +39,9 @@ interface SnackbarState {
 export interface CarPoolingTripDataProps {
   tripId?: string;
   codespace?: string;
+  // When true, the trip identified by tripId is loaded only to pre-fill the
+  // form: it's saved as a brand-new trip (fresh id/code) rather than edited.
+  duplicate?: boolean;
   onAddFlexibleStop: () => void;
   onZoomToFeature: (id: string) => void;
   onZoomToAllFeatures: () => void;
@@ -64,6 +68,7 @@ const CarPoolingTripData = forwardRef<CarPoolingTripDataHandle, CarPoolingTripDa
       onZoomToAllFeatures,
       tripId,
       codespace,
+      duplicate,
       loadedFlexibleStop,
       onDepartureStopChange,
       onArrivalStopChange,
@@ -192,6 +197,18 @@ const CarPoolingTripData = forwardRef<CarPoolingTripDataHandle, CarPoolingTripDa
             if (result.data?.extraJourney) {
               const journey = result.data.extraJourney as Extrajourney;
               const state = mapToFormData(journey, authority.id);
+              if (duplicate) {
+                // A duplicate copies every field of the source trip but is a new
+                // trip, so it needs its own identity: drop the source id and mint
+                // a fresh journey code, lineRef and booking URL. The code is the
+                // stable key nunamnir/subula/OTP store the trip under — reusing it
+                // would overwrite the original instead of creating a copy.
+                const code = `${codespace}:ServiceJourney:${uuidv4()}`;
+                state.id = undefined;
+                state.estimatedVehicleJourneyCode = code;
+                state.lineRef = `${codespace}:CarPooling:${uuidv4()}`;
+                state.contactUrl = `${window.location.origin}/book-trip/${codespace}/${code}`;
+              }
               setInitialState(state);
               setTripData(journey);
               loadStopsFromJourney(journey);
@@ -201,9 +218,12 @@ const CarPoolingTripData = forwardRef<CarPoolingTripDataHandle, CarPoolingTripDa
             showSnackbar(error.message || 'Noe gikk galt under lesing.', 'error');
           });
       };
-      setCurrentTripId(tripId);
+      // A duplicate must not carry the source's id forward: on submit the form
+      // falls back to currentTripId when it has no id of its own, so keeping the
+      // source id here would make "save" overwrite the original trip instead.
+      setCurrentTripId(duplicate ? undefined : tripId);
       loadInitialState(tripId);
-    }, [authorities, codespace, loadStopsFromJourney, queryOneExtraJourney, tripId]);
+    }, [authorities, codespace, duplicate, loadStopsFromJourney, queryOneExtraJourney, tripId]);
 
     useImperativeHandle(
       ref,

--- a/src/features/planned-trips/CarPoolingTrips.test.tsx
+++ b/src/features/planned-trips/CarPoolingTrips.test.tsx
@@ -8,6 +8,14 @@ import CarPoolingTrips from './CarPoolingTrips';
 const queryExtraJourneys = vi.fn();
 const cancelExtrajourney = vi.fn();
 
+// Capture navigation so the action buttons' targets can be asserted; the rest
+// of react-router-dom (MemoryRouter, useLocation) stays real.
+const { navigateMock } = vi.hoisted(() => ({ navigateMock: vi.fn() }));
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
 vi.mock('./hooks/useQueryExtraJourney.tsx', () => ({
   useQueryExtraJourney: () => queryExtraJourneys,
 }));
@@ -66,6 +74,7 @@ describe('CarPoolingTrips', () => {
   beforeEach(() => {
     queryExtraJourneys.mockReset();
     cancelExtrajourney.mockReset();
+    navigateMock.mockReset();
     nowSpy = vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-05-20T00:00:00.000Z').valueOf());
   });
   afterEach(() => {
@@ -315,6 +324,19 @@ describe('CarPoolingTrips', () => {
     const rows = await screen.findAllByRole('row', { name: /Vikersund/ });
     expect(rows).toHaveLength(1);
     expect(within(rows[0]).getByText('Cancelled')).toBeInTheDocument();
+  });
+
+  it('opens the plan-trip form pre-filled as a duplicate when Duplicate is clicked', async () => {
+    queryExtraJourneys.mockResolvedValue({ data: [trip()] });
+
+    renderInRouter();
+
+    const row = await screen.findByRole('row', { name: /Oslo S/ });
+    await userEvent.click(within(row).getByRole('button', { name: /Duplicate/ }));
+
+    // Reuses the edit route with ?duplicate=true so the form clones the trip
+    // into a new one rather than editing it in place.
+    expect(navigateMock).toHaveBeenCalledWith('/plan-trip/ENT/ENT:ServiceJourney:1?duplicate=true');
   });
 
   it('cancels a whole trip when the Cancel button is clicked', async () => {

--- a/src/features/planned-trips/CarPoolingTrips.tsx
+++ b/src/features/planned-trips/CarPoolingTrips.tsx
@@ -241,7 +241,7 @@ export default function CarPoolingTrips() {
     {
       field: 'actions',
       headerName: 'Actions',
-      width: 300,
+      width: 400,
       sortable: false,
       filterable: false,
       renderCell: params => {
@@ -263,6 +263,20 @@ export default function CarPoolingTrips() {
                 onClick={() => navigate(`/plan-trip/${codespace}/${params.row.id}`)}
               >
                 Edit
+              </Button>
+            )}
+            {canModify && (
+              <Button
+                variant="outlined"
+                size="small"
+                // Duplicate opens the plan-trip form pre-filled with this trip's
+                // values but as a *new* trip (fresh id/code) — the `duplicate`
+                // flag tells the form to mint a new identity rather than edit
+                // this one in place.
+                onClick={() => navigate(`/plan-trip/${codespace}/${params.row.id}?duplicate=true`)}
+                style={{ marginLeft: 8 }}
+              >
+                Duplicate
               </Button>
             )}
             {canModify && (


### PR DESCRIPTION
Duplicate opens the plan-trip form pre-filled with an existing trip's values but as a brand-new trip: it reuses the edit route with ?duplicate=true, then drops the source id and mints a fresh journey code, lineRef and booking URL. currentTripId is left unset so saving creates a copy rather than overwriting the original.