### PR TITLE
Rebrand to "Entur's carpooling test client" and redesign landing page

### DIFF
--- a/.github/environments/theme-dev.json
+++ b/.github/environments/theme-dev.json
@@ -1,5 +1,5 @@
 {
-  "applicationName": "Entur Car Pooling PoC",
+  "applicationName": "Entur's carpooling test client",
   "companyName": "Entur",
   "palette": {
     "primary": { "main": "#181C56" },

--- a/.github/environments/theme-tst.json
+++ b/.github/environments/theme-tst.json
@@ -1,5 +1,5 @@
 {
-  "applicationName": "Entur Car Pooling PoC",
+  "applicationName": "Entur's carpooling test client",
   "companyName": "Entur",
   "palette": {
     "primary": { "main": "#181C56" },

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -31,6 +31,9 @@ jobs:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_TADMUSTUM_DEV }}
           channelId: live
           projectId: ent-tadmustum-dev
+          # Pinned: firebase-tools 15.22.1-15.22.3 hit "premature close" on every
+          # API call, and the non-idempotent retries fail deploys (409/400).
+          firebaseToolsVersion: "15.22.0"
 
   deploy_tst:
     needs: build_and_deploy
@@ -55,3 +58,6 @@ jobs:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_TADMUSTUM_TST }}
           channelId: live
           projectId: ent-tadmustum-tst
+          # Pinned: firebase-tools 15.22.1-15.22.3 hit "premature close" on every
+          # API call, and the non-idempotent retries fail deploys (409/400).
+          firebaseToolsVersion: "15.22.0"

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,7 +13,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          # Pinned: Node 22.23.0 / 24.17.0 carry nodejs/node#63989, a keep-alive
+          # socket bug that makes firebase-tools fail with "Premature close" when
+          # authenticating to googleapis. 22.22.3 predates it.
+          node-version: 22.22.3
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
@@ -42,7 +45,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          # Pinned: Node 22.23.0 / 24.17.0 carry nodejs/node#63989, a keep-alive
+          # socket bug that makes firebase-tools fail with "Premature close" when
+          # authenticating to googleapis. 22.22.3 predates it.
+          node-version: 22.22.3
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -15,7 +15,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          # Pinned: Node 22.23.0 / 24.17.0 carry nodejs/node#63989, a keep-alive
+          # socket bug that makes firebase-tools fail with "Premature close" when
+          # authenticating to googleapis. 22.22.3 predates it.
+          node-version: 22.22.3
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -28,3 +28,6 @@ jobs:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENT_TADMUSTUM_DEV }}
           projectId: ent-tadmustum-dev
+          # Pinned: firebase-tools 15.22.1-15.22.3 hit "premature close" on every
+          # API call, and the non-idempotent retries fail channel deploys (409/400).
+          firebaseToolsVersion: "15.22.0"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Tadmustum
-Starting point for Entur PoC for Car Pooling.
+Starting point for Entur's carpooling test client.

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>EnTur Car Pooling POC</title>
+    <title>Entur's carpooling test client</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/features/landing-page/CarpoolIcon.tsx
+++ b/src/features/landing-page/CarpoolIcon.tsx
@@ -1,0 +1,48 @@
+import { SvgIcon } from '@mui/material';
+import type { SvgIconProps } from '@mui/material';
+
+// The old landing-page logo was MUI's front-view `DirectionsCar`. This keeps that
+// exact car (so the silhouette stays familiar and the frame stays continuous) and
+// adds the carpooling story: a tiny passenger behind the windscreen and a
+// minimalistic stick-man stepping up to get in.
+//
+// The car's windscreen is a hole in the silhouette (the avatar background shows
+// through it), so the passenger is drawn in `currentColor` to stand out against it.
+const CAR_PATH =
+  'M18.92 5.01C18.72 4.42 18.16 4 17.5 4h-11c-.66 0-1.21.42-1.42 1.01L3 12v8c0 .55.45 1 1 1h1' +
+  'c.55 0 1-.45 1-1v-1h12v1c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-8l-2.08-6.99zM6.5 16c-.83 0-1.5-.67-1.5-1.5' +
+  'S5.67 13 6.5 13s1.5.67 1.5 1.5S7.33 16 6.5 16zm11 0c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5' +
+  '-.67 1.5-1.5 1.5zM5 11l1.5-5.5h11L19 11H5z';
+
+export default function CarpoolIcon(props: SvgIconProps) {
+  // Square viewBox cropped around the artwork: it keeps the car + person centred and
+  // filling the icon box (a non-square viewBox makes SvgIcon letterbox it off-centre).
+  return (
+    <SvgIcon viewBox="1.5 1.65 19 19" {...props}>
+      {/* Front-view car, shrunk and shifted right to leave room for the person on the left. */}
+      <g transform="translate(7.6 3.5) scale(0.6)">
+        <path d={CAR_PATH} />
+        {/* Tiny stick-man head + neck inside the (dark) windscreen. */}
+        <circle cx="14.5" cy="8" r="1.2" fill="none" stroke="currentColor" strokeWidth={1.15} />
+        <path
+          d="M14.5 9.2 V10.7"
+          stroke="currentColor"
+          strokeWidth={1.15}
+          strokeLinecap="round"
+          fill="none"
+        />
+      </g>
+
+      {/* Future passenger: stick-man (open-ring head) on the left, stepping up to get in. */}
+      <circle cx="3.6" cy="8" r="1.2" fill="none" stroke="currentColor" strokeWidth={1.2} />
+      <path
+        d="M3.6 9.2 V12.8 M3.6 12.8 L2.6 15.8 M3.6 12.8 L4.6 15.8 M3.6 10 L2.5 11.3 M3.6 10 L4.7 11.3"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </SvgIcon>
+  );
+}

--- a/src/features/landing-page/Home.tsx
+++ b/src/features/landing-page/Home.tsx
@@ -1,49 +1,63 @@
-import { Container, Box, Typography, Link } from '@mui/material';
+import { Container, Box, Typography, Button, Stack, Avatar } from '@mui/material';
+import { Add, FormatListBulleted } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
+import CarpoolIcon from './CarpoolIcon';
 
 export default function Home() {
   const navigate = useNavigate();
 
   return (
     <Container maxWidth="md">
-      <Box sx={{ my: 8, textAlign: 'left' }}>
-        <Typography variant="h3" component="h1" gutterBottom>
-          Welcome to Entur Car Pooling PoC
+      <Box
+        sx={{
+          my: { xs: 6, md: 10 },
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          textAlign: 'center',
+          gap: 3,
+        }}
+      >
+        <Avatar sx={{ bgcolor: 'primary.main', width: 88, height: 88 }}>
+          <CarpoolIcon sx={{ fontSize: 60 }} />
+        </Avatar>
+
+        <Typography variant="h3" component="h1" fontWeight={700}>
+          Welcome to Entur's carpooling test client
         </Typography>
-        <Typography variant="body1" sx={{ mb: 2 }}>
-          Enturs Car Pooling PoC frontend app for testing creation of Car Pooling messages for
-          making such trips available in a journey planner. This app uses a GraphQL api to create
-          trips in a backend app, this backend app will then relay these to the journey planner in
-          SIRI format.
+
+        <Typography
+          variant="h6"
+          component="p"
+          color="text.secondary"
+          sx={{ maxWidth: 620, fontWeight: 400 }}
+        >
+          A frontend app for creating carpooling SIRI messages and making the resulting trips
+          available in a journey planner.
         </Typography>
-        <Typography variant="body1">
-          EnTur Car Pooling PoC cannot at the moment describe:
-        </Typography>
-        <Box component="ul" sx={{ textAlign: 'left', display: 'inline-block', pl: 2 }}>
-          <Typography component="li" variant="body1">
-            Contact details about the driver, amongst these the name
-          </Typography>
-          <Typography component="li" variant="body1">
-            Make and model of the car or other identifying features such as license plate or colour
-          </Typography>
-          <Typography component="li" variant="body1">
-            Number of free seats in the car
-          </Typography>
-        </Box>
-        <Typography variant="body1" sx={{ mb: 2 }}>
-          The current state of the PoC is to enable non technical users to create SIRI messages that
-          can be consumed by a journey planner, and verify that the journey planner can create
-          flexible temporary stop places for Car Pooling trips.
-        </Typography>
-        <Typography variant="body1" sx={{ mb: 2 }}>
-          Next step is to see if SIRI is a good fit for Car Pooling messages and what needs to be
-          put into a profile to facilitate it's adoption.
-        </Typography>
-        <Typography variant="body1">
-          Go to <Link onClick={() => navigate('/plan-trip')}>Plan trip</Link> to create a new Car
-          Pooling Message, or <Link onClick={() => navigate('/trips')}>Planned trips</Link> to see
-          messages that's created.
-        </Typography>
+
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          sx={{ mt: 2, width: { xs: '100%', sm: 'auto' }, maxWidth: { xs: 360, sm: 'none' } }}
+        >
+          <Button
+            variant="contained"
+            size="large"
+            startIcon={<Add />}
+            onClick={() => navigate('/plan-trip')}
+          >
+            Plan trip
+          </Button>
+          <Button
+            variant="contained"
+            size="large"
+            startIcon={<FormatListBulleted />}
+            onClick={() => navigate('/trips')}
+          >
+            Planned trips
+          </Button>
+        </Stack>
       </Box>
     </Container>
   );

--- a/src/features/passenger-booking/PassengerTripBooking.tsx
+++ b/src/features/passenger-booking/PassengerTripBooking.tsx
@@ -356,7 +356,7 @@ export default function PassengerTripBooking() {
     if (navigator.share && bookingData.pickupCoordinates && bookingData.dropoffCoordinates) {
       try {
         await navigator.share({
-          title: 'Car Pooling Trip Booking',
+          title: 'Carpooling Trip Booking',
           text: `Book a ride on ${trip?.estimatedVehicleJourney.publishedLineName}`,
           url: currentURL,
         });


### PR DESCRIPTION
- Rename the app from "Entur Car Pooling PoC" to "Entur's carpooling test client" across theme configs, the document title, README, and the UI.
- Normalize the "Car Pooling" spelling to "carpooling".
- Rebuild the landing page as a centred hero: trimmed copy, a logo avatar, and "Plan trip" / "Planned trips" action buttons.
- Add CarpoolIcon: a front-view car (the old DirectionsCar glyph) with a driver behind the windscreen and a stick-man stepping up to get in.