### PR TITLE
Remove click-to-add stops on the plan-trip map

### DIFF
--- a/src/features/plan-trip/hooks/useStopsController.tsx
+++ b/src/features/plan-trip/hooks/useStopsController.tsx
@@ -77,19 +77,17 @@ export function useStopsController({
 
   const onStopCreated = useCallback(
     (feature: Feature) => {
+      // Stops are only created through the Add stop buttons, which set
+      // currentStop before starting the draw. A create without a target (e.g.
+      // a stray draw event) is ignored rather than guessed into a slot.
       if (currentStop === 'departure') {
         setDepartureStop(feature);
       } else if (currentStop === 'arrival') {
         setArrivalStop(feature);
-      } else if (!departureStop) {
-        // No active draw target (click-to-add path): fill the next empty slot.
-        setDepartureStop(feature);
-      } else if (!arrivalStop) {
-        setArrivalStop(feature);
       }
       setCurrentStop(null);
     },
-    [currentStop, departureStop, arrivalStop]
+    [currentStop]
   );
 
   const onDrawingStateChange = useCallback((isDrawing: boolean) => {

--- a/src/shared/components/EditableMap.tsx
+++ b/src/shared/components/EditableMap.tsx
@@ -21,7 +21,6 @@ import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import type { Feature, Point, LineString } from 'geojson';
 import type { RouteLegGeometries } from '../api/routeLegChain.tsx';
 import RouteLineLayers from './RouteLineLayers.tsx';
-import { v4 as uuidv4 } from 'uuid';
 import { MAPBOXDRAW_DEFAULT_CONSTRUCTOR } from '../util/MAPBOXDRAW_DEFAULT_CONSTRUCTOR.tsx';
 import type { IControl } from 'maplibre-gl';
 import maplibregl from 'maplibre-gl';
@@ -66,7 +65,7 @@ const EditableMap = forwardRef<EditableMapHandle, EditableMapProps>(
     // Tracked as a ref because it's only inspected in event handlers and the
     // value never needs to drive a render.
     const isDrawingRef = useRef<boolean>(false);
-    // Ref-based so multiple call sites (drawFeature, addFeatures, onMapClick)
+    // Ref-based so multiple call sites (drawFeature, addFeatures)
     // can lazily init without racing through async setState.
     const drawToolRef = useRef<MapboxDraw | null>(null);
 
@@ -183,34 +182,6 @@ const EditableMap = forwardRef<EditableMapHandle, EditableMapProps>(
       features.forEach(feature => tool.add(feature));
     };
 
-    const onMapClick = useCallback(
-      (e: { lngLat: { lng: number; lat: number }; point: { x: number; y: number } }) => {
-        // Don't interfere with an active draw — MapboxDraw owns the click in draw_point mode.
-        if (isDrawingRef.current) return;
-
-        const zoom = mapRef.current?.getZoom() ?? 0;
-        if (zoom <= 15) return;
-
-        // Don't drop a new stop on top of an existing one — let the click select it instead.
-        if ((drawToolRef.current?.getFeatureIdsAt(e.point) ?? []).length > 0) return;
-
-        const numStops = (departureStopId ? 1 : 0) + (arrivalStopId ? 1 : 0);
-        if (numStops >= 2) return;
-
-        const newFeature: Feature<Point> = {
-          id: uuidv4(),
-          type: 'Feature',
-          geometry: { type: 'Point', coordinates: [e.lngLat.lng, e.lngLat.lat] },
-          properties: {},
-        };
-
-        ensureDrawTool().add(newFeature);
-        setFeatures(curr => ({ ...curr, [String(newFeature.id)]: newFeature }));
-        callbacksRef.current.onStopCreated?.(newFeature);
-      },
-      [departureStopId, arrivalStopId, ensureDrawTool]
-    );
-
     const featureArray = useMemo(() => {
       return Object.values(features).sort((a, b) => {
         if (String(a.id) === departureStopId) return -1;
@@ -297,7 +268,6 @@ const EditableMap = forwardRef<EditableMapHandle, EditableMapProps>(
           zoom: 8,
         }}
         mapStyle={mapStyle}
-        onClick={onMapClick}
       >
         <NavigationControl position="bottom-right" />
         <GeolocateControl position="bottom-right" />


### PR DESCRIPTION
Placing a stop via the Add stop button while zoomed in past level 15 created two stacked stops from one click: mapbox-gl-draw synthesizes its click from mouseup and fires draw.create there, while the map's onClick (the click-to-add path) fires later on the DOM click event of the same gesture. By then the drawing flag had already been reset, so the guard was disarmed and a phantom second stop was created at the same point and slotted as the arrival.

Stops are now only created through the Add stop buttons, so drop the click-to-add handler and the controller's fill-next-empty-slot fallback that existed solely to serve it; a create without an explicit target is ignored instead of guessed into a slot.