### PR TITLE
Hardcode the carpool trip operator to Entur

### DIFF
--- a/src/features/plan-trip/components/CarPoolingTripDataForm.authority.test.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.authority.test.tsx
@@ -33,10 +33,6 @@ vi.mock('@mui/x-date-pickers/DateTimePicker', () => ({
 }));
 
 vi.mock('../hooks/useStreetRoute', () => ({ useStreetRoute: () => streetRoute }));
-vi.mock('../hooks/useOperators', () => {
-  const operators = [{ id: 'ENT:Operator:1', name: 'Entur' }];
-  return { useOperators: () => operators };
-});
 // Two authorities in different codespaces, so the Authority picker is rendered.
 // Stable reference (built once) to avoid re-firing the effect on every render.
 vi.mock('../../../shared/hooks/useAuthorities', () => {

--- a/src/features/plan-trip/components/CarPoolingTripDataForm.test.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.test.tsx
@@ -37,15 +37,11 @@ vi.mock('@mui/x-date-pickers/DateTimePicker', () => ({
 }));
 
 vi.mock('../hooks/useStreetRoute', () => ({ useStreetRoute: () => streetRoute }));
-// The hooks below must return STABLE references: the component lists the
-// operators/authorities arrays in a useEffect dependency array, so handing back
-// a fresh array literal on every render would re-fire the effect (which calls
-// setValue) and spin into an infinite render loop. The real hooks memoize their
-// results; the mocks build the arrays once and reuse them.
-vi.mock('../hooks/useOperators', () => {
-  const operators = [{ id: 'ENT:Operator:1', name: 'Entur' }];
-  return { useOperators: () => operators };
-});
+// The hook below must return a STABLE reference: the component lists the
+// authorities array in a useEffect dependency array, so handing back a fresh
+// array literal on every render would re-fire the effect (which calls setValue)
+// and spin into an infinite render loop. The real hook memoizes its result; the
+// mock builds the array once and reuses it.
 vi.mock('../../../shared/hooks/useAuthorities', () => {
   const adminAuthorities = [{ id: 'ENT:Authority:ENT', name: 'Entur' }];
   return { useAuthorities: () => ({ adminAuthorities }) };
@@ -312,8 +308,18 @@ describe('CarPoolingTripDataForm — operator is locked to Entur', () => {
     const operator = screen.getByRole('combobox', { name: 'Operator' });
     expect(operator).toHaveAttribute('aria-disabled', 'true');
 
-    // It is still auto-populated with the Entur operator, so the required field
-    // passes validation despite being read-only.
+    // The value is hardcoded rather than fetched, so the required field passes
+    // validation immediately — no journey-planner round trip to wait for.
+    await waitFor(() => expect(operator).toHaveTextContent('Entur'));
+  });
+
+  it('replaces another codespace operator on an existing trip with Entur', async () => {
+    // A trip created before the operator was locked down can carry any codespace's
+    // operatorRef. Entur is the only accepted value and the picker is disabled, so
+    // the form must overwrite it — otherwise the trip could never be saved again.
+    renderForm({ initialState: { ...editingState(), operator: 'GOA:Operator:GOA' } });
+
+    const operator = screen.getByRole('combobox', { name: 'Operator' });
     await waitFor(() => expect(operator).toHaveTextContent('Entur'));
   });
 });

--- a/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
+++ b/src/features/plan-trip/components/CarPoolingTripDataForm.tsx
@@ -25,10 +25,10 @@ import { useEffect, useMemo, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { useAuthorities } from '../../../shared/hooks/useAuthorities.tsx';
-import { useOperators } from '../hooks/useOperators.tsx';
 import { useStreetRoute } from '../hooks/useStreetRoute.tsx';
 import type { Feature, Point, Position } from 'geojson';
 import type { CarPoolingTripDataFormData } from '../model/CarPoolingTripDataFormData.tsx';
+import { ENTUR_OPERATOR } from '../model/enturOperator.tsx';
 import {
   carPoolingTripDataSchema,
   MAX_TRIP_DURATION_MINUTES,
@@ -96,7 +96,6 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
   // original (and nunamnir now rejects the mismatch outright). So the authority
   // is fixed once a trip exists — lock the picker when editing.
   const isEditing = !!initialState;
-  const operators = useOperators();
 
   // New trips default to departing exactly a week from now. Computed once so it
   // stays stable across renders (and so Reset returns to the same value).
@@ -117,7 +116,7 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     mode: 'onBlur', // or "onChange", depending on UX preference
     defaultValues: {
       authority: '',
-      operator: '',
+      operator: ENTUR_OPERATOR.id,
       departureStopName: 'Origin',
       departureDatetime: defaultDeparture,
       estimateArrivalAutomatically: true,
@@ -184,21 +183,12 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
       setValue('contactUrl', `${window.location.origin}/book-trip/${codespace}/${code}`);
     }
 
-    if (operators.length && !operator) {
-      // Prefer an Entur operator when one exists; otherwise fall back to the
-      // first operator belonging to the selected authority's codespace (operator
-      // ids look like `<codespace>:Operator:<X>`), so staging environments that
-      // have no Entur operator still get a sensible default instead of a blank,
-      // required field.
-      const enturOperator = operators.find(o => o.name.toLowerCase().includes('entur'));
-      const codespace = authority ? authority.split(':')[0] : undefined;
-      const codespaceOperator = codespace
-        ? operators.find(o => o.id.split(':')[0] === codespace)
-        : undefined;
-      const defaultOperator = enturOperator ?? codespaceOperator;
-      if (defaultOperator) {
-        setValue('operator', defaultOperator.id);
-      }
+    // The operator is hardcoded to Entur, so re-assert it after an existing trip
+    // has been loaded: a trip created earlier can carry another codespace's
+    // operatorRef, and with the picker locked that value would fail validation
+    // with no way for the user to correct it.
+    if (operator !== ENTUR_OPERATOR.id) {
+      setValue('operator', ENTUR_OPERATOR.id);
     }
 
     if (mapDepartureFlexibleStop) {
@@ -244,7 +234,6 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
     authorities,
     authority,
     contactUrl,
-    operators,
     operator,
     mapDepartureFlexibleStop,
     mapDestinationFlexibleStop,
@@ -653,21 +642,12 @@ export default function CarPoolingTripDataForm(props: CarPoolingTripDataFormProp
           render={({ field }) => {
             return (
               // Only Entur is accepted as the operator for now and the field has
-              // no downstream consumer yet (see the notice below), so the picker
-              // is locked to the auto-selected Entur operator rather than letting
-              // the choice drift to a value the backend would reject.
+              // no downstream consumer yet (see the notice below), so the operator
+              // is hardcoded (ENTUR_OPERATOR) instead of being picked out of the
+              // journey planner's per-environment operator list. Kept as a locked
+              // Select so the value stays visible in the form.
               <Select {...field} labelId="operator-label" label="Operator" disabled>
-                <MenuItem value="" disabled>
-                  <em>Operator</em>
-                </MenuItem>
-                {field.value && !operators.some(o => o.id === field.value) && (
-                  <MenuItem value={field.value}>{field.value}</MenuItem>
-                )}
-                {operators.map(operator => (
-                  <MenuItem key={operator.id} value={operator.id}>
-                    {operator.name}
-                  </MenuItem>
-                ))}
+                <MenuItem value={ENTUR_OPERATOR.id}>{ENTUR_OPERATOR.name}</MenuItem>
               </Select>
             );
           }}

--- a/src/features/plan-trip/model/enturOperator.tsx
+++ b/src/features/plan-trip/model/enturOperator.tsx
@@ -1,0 +1,16 @@
+/**
+ * The one operator carpool trips are created with.
+ *
+ * The form used to fetch the journey planner's full operator list and pick an
+ * Entur entry out of it, but only Entur is accepted (see
+ * carPoolingTripDataSchema) and the value is dead data downstream, so there is
+ * nothing to choose between. Worse, the list is per-environment NeTEx data:
+ * staging has no `ENT:` operator at all, so the auto-pick fell back to another
+ * codespace's operator and then failed validation in a locked field.
+ *
+ * Id and name mirror the `ENT:` operator in Entur's NeTEx data.
+ */
+export const ENTUR_OPERATOR = {
+  id: 'ENT:Operator:ENT',
+  name: 'Entur',
+} as const;


### PR DESCRIPTION
The plan-trip form fetched the journey planner's full operator list (`operators` on journey-planner v3) only to auto-pick an Entur entry out of it, since the schema accepts nothing but `ENT:` and the value has no downstream consumer.

That list is per-environment NeTEx data, and staging has no `ENT:` operator at all: the fallback then picked another codespace's operator (GOA:Operator:GOA), which the schema rejected in a disabled field — an unfixable validation error blocking trip creation in test.

Drop the API dependency and hardcode the one accepted operator. An existing trip's operatorRef is overwritten with it on load, so trips created before the field was locked down stay editable.

useOperators and api.getOperators are kept: the flex tour form on add-flex-support needs the real list for a non-ENT operator.